### PR TITLE
Get update filename from Content-Disposition header if available

### DIFF
--- a/src/download.h
+++ b/src/download.h
@@ -43,6 +43,11 @@ struct IDownloadSink
      */
     virtual void SetLength(size_t len) = 0;
 
+    /**
+       Inform the sink of detected filename
+     */
+    virtual void SetFilename(const std::string& filename) = 0;
+
     /// Add chunk of downloaded data
     virtual void Add(const void *data, size_t len) = 0;
 };
@@ -53,6 +58,8 @@ struct IDownloadSink
 struct StringDownloadSink : public IDownloadSink
 {
     virtual void SetLength(size_t) {}
+
+    virtual void SetFilename(const std::string& filename) {}
 
     virtual void Add(const void *data, size_t len)
     {


### PR DESCRIPTION
Hi! Thanks a lot for winsparkle, we've been using it since version 0.2 without a glitch!

On to the code!

Our appcast URL is something like http://domain/foo.php?update which then returns the filename in the Content-Disposition header. This pull request uses the content of that header if available as the temporary filename for the download.

PS: My C++ kungfu is not very strong, if you'd like to see this done differently please let me know and I'll try to make it right!
