### PR TITLE
Added callback to allow host to localize strings

### DIFF
--- a/include/winsparkle.h
+++ b/include/winsparkle.h
@@ -306,6 +306,32 @@ WIN_SPARKLE_API void __cdecl win_sparkle_check_update_without_ui();
 
 //@}
 
+/*--------------------------------------------------------------------------*
+                           Localization Callback
+ *--------------------------------------------------------------------------*/
+
+/**
+    @name Localize WinSparkle UI strings via an application callback
+ */
+//@{
+
+/// Callback type for win_sparkle_localized_string_callback()
+typedef const char* (__cdecl *win_sparkle_localized_string_callback_t)( const char *keyStr );
+
+/**
+	Set callback for localizing WinSparkle UI strings
+
+    This callback will be called to ask the host to localize a string required for display in the WinSparkle UI.
+	The host should return a localized string or the string passed in if a translation is not available.
+	The strings required by WinSparkle are found in ui.cpp. Search for use of the __() macro to identify these strings.
+
+	Note: If this callback is set, it will override the standard wx localization mechanism.
+*/
+WIN_SPARKLE_API void __cdecl set_win_sparkle_localized_string_callback(win_sparkle_localized_string_callback_t callback);
+
+//@}
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/dll_api.cpp
+++ b/src/dll_api.cpp
@@ -252,5 +252,17 @@ WIN_SPARKLE_API void __cdecl win_sparkle_check_update_without_ui()
     CATCH_ALL_EXCEPTIONS
 }
 
+/*--------------------------------------------------------------------------*
+                           Localization Callback
+ *--------------------------------------------------------------------------*/
+
+WIN_SPARKLE_API void __cdecl set_win_sparkle_localized_string_callback(win_sparkle_localized_string_callback_t callback)
+{
+	try
+    {
+        UI::SetLocalizedStringCallback(callback);
+    }
+    CATCH_ALL_EXCEPTIONS
+}
 
 } // extern "C"

--- a/src/ui.h
+++ b/src/ui.h
@@ -26,8 +26,10 @@
 #ifndef _ui_h_
 #define _ui_h_
 
+#include "winsparkle.h"
 #include "threads.h"
 #include "appcast.h"
+#include <wx/stattext.h>
 
 namespace winsparkle
 {
@@ -105,6 +107,15 @@ public:
      */
     static void SetDllHINSTANCE(HINSTANCE h) { ms_hInstance = h; }
 
+	    /// Set the win_sparkle_localized_string_callback_t function
+    static void SetLocalizedStringCallback(win_sparkle_localized_string_callback_t callback)
+    {
+        CriticalSectionLocker lock(ms_csVars);
+        ms_cbLocalizedString = callback;
+    }
+
+	static const wxString LocalizedString( const char *str );
+
 protected:
     virtual void Run();
     virtual bool IsJoinable() const { return true; }
@@ -113,6 +124,11 @@ private:
     UI();
 
     static HINSTANCE ms_hInstance;
+ 
+	// guards the variables below:
+    static CriticalSection ms_csVars;
+
+    static win_sparkle_localized_string_callback_t     ms_cbLocalizedString;
 
     friend class UIThreadAccess;
 };


### PR DESCRIPTION
win_sparkle_localized_string_callback_t allows host to localize strings
if desired. If not set, continues to rely on wxwidgets
internationalization method.
