### PR TITLE
Ctrlprint set skip this version

### DIFF
--- a/include/winsparkle.h
+++ b/include/winsparkle.h
@@ -222,6 +222,15 @@ WIN_SPARKLE_API int __cdecl win_sparkle_get_update_check_interval();
 */
 WIN_SPARKLE_API time_t __cdecl win_sparkle_get_last_check_time();
 
+/**
+    Set the version to skip.
+
+    Set the version to an empty string to clear value.
+
+    @since 0.4
+*/
+WIN_SPARKLE_API void __cdecl win_sparkle_set_skip_this_version(const char* version);
+
 /// Callback type for win_sparkle_can_shutdown_callback()
 typedef int (__cdecl *win_sparkle_can_shutdown_callback_t)();
 

--- a/src/dll_api.cpp
+++ b/src/dll_api.cpp
@@ -219,6 +219,11 @@ WIN_SPARKLE_API time_t __cdecl win_sparkle_get_last_check_time()
     return DEFAULT_LAST_CHECK_TIME;
 }
 
+WIN_SPARKLE_API void __cdecl win_sparkle_set_skip_this_version(const char* version)
+{
+    Settings::WriteConfigValue("SkipThisVersion", version);
+}
+
 WIN_SPARKLE_API void __cdecl win_sparkle_set_can_shutdown_callback(win_sparkle_can_shutdown_callback_t callback)
 {
     try


### PR DESCRIPTION
Added possibility to the dll api to:
1. Get the time stamp of the last check, to be able to show it in a preferences UI.
2. Set the "SkipThisVersion", to allow users to change their minds.
