### PR TITLE
Make windows scalable by DPI

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -171,6 +171,8 @@ protected:
 protected:
     // sizer for the main area of the dialog (to the right of the icon)
     wxSizer      *m_mainAreaSizer;
+    double        m_dpiX;
+    double        m_dpiY;
 
     static const int MESSAGE_AREA_WIDTH = 300;
 };
@@ -181,6 +183,14 @@ WinSparkleDialog::WinSparkleDialog()
                wxDefaultPosition, wxDefaultSize,
                wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
 {
+    HDC screen = GetDC(NULL);
+    double hPixelsPerInch = GetDeviceCaps(screen, LOGPIXELSX);
+    double vPixelsPerInch = GetDeviceCaps(screen, LOGPIXELSY);
+    ReleaseDC(NULL, screen);
+
+    m_dpiX = hPixelsPerInch / 96.0;
+    m_dpiY = vPixelsPerInch / 96.0;
+
     SetIcons(wxICON(UpdateAvailable));
 
     wxSizer *topSizer = new wxBoxSizer(wxHORIZONTAL);
@@ -336,16 +346,16 @@ UpdateDialog::UpdateDialog()
 {
     m_heading = new wxStaticText(this, wxID_ANY, "");
     SetHeadingFont(m_heading);
-    m_mainAreaSizer->Add(m_heading, wxSizerFlags(0).Expand().Border(wxBOTTOM, 10));
+    m_mainAreaSizer->Add(m_heading, wxSizerFlags(0).Expand().Border(wxBOTTOM, 10 * m_dpiY));
 
     m_message = new wxStaticText(this, wxID_ANY, "",
-                                 wxDefaultPosition, wxSize(MESSAGE_AREA_WIDTH, -1));
+                                 wxDefaultPosition, wxSize(MESSAGE_AREA_WIDTH * m_dpiX, -1));
     m_mainAreaSizer->Add(m_message, wxSizerFlags(0).Expand());
 
     m_progress = new wxGauge(this, wxID_ANY, 100,
-                             wxDefaultPosition, wxSize(MESSAGE_AREA_WIDTH, 16));
+                             wxDefaultPosition, wxSize(MESSAGE_AREA_WIDTH * m_dpiX, 16 * m_dpiY));
     m_progressLabel = new wxStaticText(this, wxID_ANY, "");
-    m_mainAreaSizer->Add(m_progress, wxSizerFlags(0).Expand().Border(wxTOP|wxBOTTOM, 10));
+    m_mainAreaSizer->Add(m_progress, wxSizerFlags(0).Expand().Border(wxTOP|wxBOTTOM, 10 * m_dpiY));
     m_mainAreaSizer->Add(m_progressLabel, wxSizerFlags(0).Expand());
     m_mainAreaSizer->AddStretchSpacer(1);
 
@@ -353,16 +363,16 @@ UpdateDialog::UpdateDialog()
 
     wxStaticText *notesLabel = new wxStaticText(this, wxID_ANY, _("Release notes:"));
     SetBoldFont(notesLabel);
-    m_releaseNotesSizer->Add(notesLabel, wxSizerFlags().Border(wxTOP, 10));
+    m_releaseNotesSizer->Add(notesLabel, wxSizerFlags().Border(wxTOP, 10 * m_dpiY));
 
     m_browserParent = new wxPanel(this, wxID_ANY,
                                   wxDefaultPosition,
-                                  wxSize(RELNOTES_WIDTH, RELNOTES_HEIGHT));
+                                  wxSize(RELNOTES_WIDTH * m_dpiX, RELNOTES_HEIGHT * m_dpiY));
     m_browserParent->SetBackgroundColour(*wxWHITE);
     m_releaseNotesSizer->Add
                          (
                              m_browserParent,
-                             wxSizerFlags(1).Expand().Border(wxTOP, 10)
+                             wxSizerFlags(1).Expand().Border(wxTOP, 10 * m_dpiY)
                          );
 
     m_mainAreaSizer->Add
@@ -378,13 +388,13 @@ UpdateDialog::UpdateDialog()
     m_updateButtonsSizer->Add
                           (
                             new wxButton(this, ID_SKIP_VERSION, _("Skip this version")),
-                            wxSizerFlags().Border(wxRIGHT, 20)
+                            wxSizerFlags().Border(wxRIGHT, 20 * m_dpiX)
                           );
     m_updateButtonsSizer->AddStretchSpacer(1);
     m_updateButtonsSizer->Add
                           (
                             new wxButton(this, ID_REMIND_LATER, _("Remind me later")),
-                            wxSizerFlags().Border(wxRIGHT, 10)
+                            wxSizerFlags().Border(wxRIGHT, 10 * m_dpiX)
                           );
     m_updateButtonsSizer->Add
                           (
@@ -409,7 +419,7 @@ UpdateDialog::UpdateDialog()
     m_mainAreaSizer->Add
                  (
                      m_buttonSizer,
-                     wxSizerFlags(0).Expand().Border(wxTOP, 10)
+                     wxSizerFlags(0).Expand().Border(wxTOP, 10 * m_dpiY)
                  );
 
     UpdateLayout();
@@ -520,7 +530,7 @@ void UpdateDialog::OnRunInstaller(wxCommandEvent&)
 void UpdateDialog::SetMessage(const wxString& text, int width)
 {
     m_message->SetLabel(text);
-    m_message->Wrap(width);
+    m_message->Wrap(width * m_dpiX);
 }
 
 
@@ -865,7 +875,7 @@ AskPermissionDialog::AskPermissionDialog()
             new wxStaticText(this, wxID_ANY,
                              _("Check for updates automatically?"));
     SetHeadingFont(heading);
-    m_mainAreaSizer->Add(heading, wxSizerFlags(0).Expand().Border(wxBOTTOM, 10));
+    m_mainAreaSizer->Add(heading, wxSizerFlags(0).Expand().Border(wxBOTTOM, 10 * m_dpiY));
 
     wxStaticText *message =
             new wxStaticText
@@ -876,9 +886,9 @@ AskPermissionDialog::AskPermissionDialog()
                         _("Should %s automatically check for updates? You can always check for updates manually from the menu."),
                         Settings::GetAppName()
                     ),
-                    wxDefaultPosition, wxSize(MESSAGE_AREA_WIDTH, -1)
+                    wxDefaultPosition, wxSize(MESSAGE_AREA_WIDTH * m_dpiX, -1)
                 );
-    message->Wrap(MESSAGE_AREA_WIDTH);
+    message->Wrap(MESSAGE_AREA_WIDTH * m_dpiX);
     m_mainAreaSizer->Add(message, wxSizerFlags(0).Expand());
 
     m_mainAreaSizer->AddStretchSpacer(1);
@@ -898,7 +908,7 @@ AskPermissionDialog::AskPermissionDialog()
     m_mainAreaSizer->Add
                  (
                      buttonSizer,
-                     wxSizerFlags(0).Right().Border(wxTOP, 10)
+                     wxSizerFlags(0).Right().Border(wxTOP, 10 * m_dpiY)
                  );
 
     UpdateLayout();


### PR DESCRIPTION
When you are using Windows under high DPI mode, the windows of WinSparkle was too small. Now it will be scaled by the DPI.

After:
![image](https://cloud.githubusercontent.com/assets/158528/4866198/03a1ac24-612a-11e4-9322-c229adcef74d.png)

Before:
![image](https://cloud.githubusercontent.com/assets/158528/4866177/e255c28a-6129-11e4-864d-15e87874adf2.png)
