### PR TITLE
Add support for visiting web site instead of download.

### DIFF
--- a/src/appcast.cpp
+++ b/src/appcast.cpp
@@ -65,7 +65,7 @@ struct ContextData
 {
     ContextData(XML_Parser& p)
         : parser(p),
-		in_channel(0), in_item(0), in_relnotes(0), in_title(0), in_description(0), in_link(0)
+        in_channel(0), in_item(0), in_relnotes(0), in_title(0), in_description(0), in_link(0)
     {}
 
     // the parser we're using

--- a/src/appcast.h
+++ b/src/appcast.h
@@ -75,9 +75,9 @@ struct Appcast
     /// Returns true if the struct constains valid data.
     bool IsValid() const { return !Version.empty(); }
 
-    /// If true, then visit the web site (WebBrowserURL) instead of downloading and
-    /// installing ourselves.
-    bool ShouldOpenWebBrowser() const { return DownloadURL.empty() && !WebBrowserURL.empty(); }
+    /// If true, then download and install the update ourselves.
+    /// If false, launch a web browser to WebBrowserURL.
+    bool HasDownload() const { return !DownloadURL.empty(); }
 };
 
 } // namespace winsparkle

--- a/src/appcast.h
+++ b/src/appcast.h
@@ -46,6 +46,9 @@ struct Appcast
     /// URL of the release notes page
     std::string ReleaseNotesURL;
 
+    /// URL to launch in web browser (instead of downloading update ourselves)
+    std::string WebBrowserURL;
+
     /// Title of the update
     std::string Title;
 
@@ -71,6 +74,10 @@ struct Appcast
 
     /// Returns true if the struct constains valid data.
     bool IsValid() const { return !Version.empty(); }
+
+    /// If true, then visit the web site (WebBrowserURL) instead of downloading and
+    /// installing ourselves.
+    bool ShouldOpenWebBrowser() const { return DownloadURL.empty() && !WebBrowserURL.empty(); }
 };
 
 } // namespace winsparkle

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -509,14 +509,9 @@ void UpdateDialog::OnRemindLater(wxCommandEvent&)
 
 void UpdateDialog::OnInstall(wxCommandEvent&)
 {
-    if ( m_appcast.ShouldOpenWebBrowser() )
+    if ( !m_appcast.HasDownload() )
     {
-        if ( ShellExecute(GetHWND(), L"open", AnsiToWide(m_appcast.WebBrowserURL).c_str(), NULL, NULL, SW_SHOWNORMAL) <= (HINSTANCE) 32 )
-        {
-            wxMessageDialog dlg(this, _("Failed to launch web browser."), _("Software Update"),
-                wxOK | wxOK_DEFAULT | wxICON_EXCLAMATION);
-            dlg.ShowModal();
-        }
+        wxLaunchDefaultBrowser(m_appcast.WebBrowserURL, wxBROWSER_NEW_WINDOW);
         Close();
     }
     else
@@ -676,9 +671,9 @@ void UpdateDialog::StateUpdateAvailable(const Appcast& info)
             wxString::Format(_("A new version of %s is available!"), appname));
 
         const char *msg = _("%s %s is now available (you have %s). Would you like to download it now?");
-        if ( info.ShouldOpenWebBrowser() ) 
+        if ( !info.HasDownload() ) 
         {
-            m_installButton->SetLabel(_("Visit web site"));
+            m_installButton->SetLabel(_("Get update"));
             msg = _("%s %s is now available (you have %s). Would you like to visit the web site to download it?");
         }
 


### PR DESCRIPTION
If an RSS entry has a <link> attribute with a valid version number and has no
<enclosure>, then WinSparkle will launch a web browser to that link rather
than downloading and installing the update itself. This will make it easier to
use WinSparkle with password-protected downloads.

Closes vslavik/winsparkle#39.