### PR TITLE
Add support for minimumSystemVersion

### DIFF
--- a/src/appcast.h
+++ b/src/appcast.h
@@ -58,6 +58,9 @@ struct Appcast
     // Operating system
     std::string Os;
 
+    // Minimum OS version required for update
+    std::string MinOSVersion;
+
     /**
         Initializes the struct with data from XML appcast feed.
 


### PR DESCRIPTION
This addresses issue #19  by adding support for the <sparkle:minimumSystemVersion> tag in an appcast.  This allows you to be able to specify an item to only be installable on at least a certain version of windows (and above).  If the tag is not specified on an item it will remain available for all versions as is the case now.  The format for the tag is MajorRelease.MiniorRelease.ServicePackLevel  with the service pack level being optional.  For example, to make an item only available on windows 7 and above add `<sparkle:minimumSystemVersion>6.1</sparkle:minimumSystemVersion>` or for XP SP3 and above, you would use `<sparkle:minimumSystemVersion>5.1.3</sparkle:minimumSystemVersion>`