### PR TITLE
Fix issue #44

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -259,7 +259,7 @@ protected:
 WinSparkleDialog::WinSparkleDialog()
     : wxDialog(NULL, wxID_ANY, _("Software Update"),
                wxDefaultPosition, wxDefaultSize,
-               wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
+               wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxDIALOG_NO_PARENT)
 {
     wxSize dpi = wxClientDC(this).GetPPI();
     m_scaleFactor = dpi.y / 96.0;


### PR DESCRIPTION
This pr will attach wxDIALOG_NO_PARENT flag to WinSparkleDialog constructor.

Fixes:
- Your app normally can quit, if you deal with CheckForUpdates dialog.
- WinSparkleDialog won't close, when CheckForUpdates dialog exists and the option button is clicked.
