### PR TITLE
Prevent downloader from running twice.

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -612,7 +612,7 @@ void UpdateDialog::OnInstall(wxCommandEvent&)
         wxLaunchDefaultBrowser(m_appcast.WebBrowserURL, wxBROWSER_NEW_WINDOW);
         Close();
     }
-    else
+    else if ( m_downloader == NULL )
     {
         StateDownloading();
 


### PR DESCRIPTION
```
- You can invoke downloader twice, if you click
  [Check for updates manually] and then,
  [Install update] at UpdateDialog.
  Repeat it once more, before downloader completes.
- App hangs due to null pointer access of m_downloader
  at UpdateDialog::StateUpdateDownloaded.
```