### PR TITLE
Pass command line arguments to downloaded installer

### DIFF
--- a/src/appcast.cpp
+++ b/src/appcast.cpp
@@ -60,6 +60,7 @@ namespace
 #define ATTR_VERSION    NS_SPARKLE_NAME("version")
 #define ATTR_SHORTVERSION NS_SPARKLE_NAME("shortVersionString")
 #define ATTR_OS         NS_SPARKLE_NAME("os")
+#define ATTR_ARGUMENTS  NS_SPARKLE_NAME("installerArguments")
 #define NODE_VERSION      ATTR_VERSION        // These can be nodes or
 #define NODE_SHORTVERSION ATTR_SHORTVERSION   // attributes.
 #define OS_MARKER       "windows"
@@ -167,6 +168,8 @@ void XMLCALL OnStartElement(void *data, const char *name, const char **attrs)
                     ctxt.items[size-1].ShortVersionString = value;
                 else if ( strcmp(name, ATTR_OS) == 0 )
                     ctxt.items[size-1].Os = value;
+                else if ( strcmp(name, ATTR_ARGUMENTS) == 0 )
+                    ctxt.items[size-1].InstallerArguments = value;
             }
         }
     }

--- a/src/appcast.h
+++ b/src/appcast.h
@@ -61,6 +61,9 @@ struct Appcast
     // Minimum OS version required for update
     std::string MinOSVersion;
 
+    // Arguments passed on the the updater executable
+    std::string InstallerArguments;
+
     /**
         Initializes the struct with data from XML appcast feed.
 

--- a/src/ui.h
+++ b/src/ui.h
@@ -86,7 +86,7 @@ public:
     /**
         Notifies the UI that an update was downloaded.
      */
-    static void NotifyUpdateDownloaded(const std::wstring& updateFile);
+    static void NotifyUpdateDownloaded(const std::wstring& updateFile, const Appcast &appcast);
 
     /**
         Shows the WinSparkle window in "checking for updates..." state.

--- a/src/updatedownloader.cpp
+++ b/src/updatedownloader.cpp
@@ -170,7 +170,7 @@ void UpdateDownloader::Run()
       UpdateDownloadSink sink(*this, tmpdir);
       DownloadFile(m_appcast.DownloadURL, &sink);
       sink.Close();
-      UI::NotifyUpdateDownloaded(sink.GetFilePath());
+      UI::NotifyUpdateDownloaded(sink.GetFilePath(), m_appcast);
     }
     catch ( ... )
     {


### PR DESCRIPTION
With this patch you can specify a <sparkle:arguments> tag in the appcast xml, and that will be passed to the downloaded executable. Intended typical use case is something like "/SILENT", see https://github.com/vslavik/winsparkle/issues/21
Thank You for pulling!