### PR TITLE
Build static version

### DIFF
--- a/include/winsparkle.h
+++ b/include/winsparkle.h
@@ -38,10 +38,14 @@
 extern "C" {
 #endif
 
-#ifdef BUILDING_WIN_SPARKLE
-    #define WIN_SPARKLE_API __declspec(dllexport)
+#ifndef WIN_SPARKLE_STATIC
+    #ifdef BUILDING_WIN_SPARKLE
+        #define WIN_SPARKLE_API __declspec(dllexport)
+    #else
+        #define WIN_SPARKLE_API __declspec(dllimport)
+    #endif
 #else
-    #define WIN_SPARKLE_API __declspec(dllimport)
+    #define WIN_SPARKLE_API
 #endif
 
 /*--------------------------------------------------------------------------*


### PR DESCRIPTION
Added new macro WIN_SPARKLE_STATIC to prevent
preprocessor magic which allow to export of library symbols.
This macro must be used to build static version of WinSparkle.