### PR TITLE
fixed warning

### DIFF
--- a/src/download.cpp
+++ b/src/download.cpp
@@ -152,7 +152,7 @@ void DownloadFile(const std::string& url, IDownloadSink *sink, int flags)
                           NULL, // lpszHeaders
                           -1,   // dwHeadersLength
                           dwFlags,
-                          NULL  // dwContext
+                          0     // dwContext
                       );
     if ( !conn )
         throw Win32Exception();


### PR DESCRIPTION
DWORD_PTR is typdef for integer not pointer.

From MSDN [DWORD_PTR](https://msdn.microsoft.com/en-us/library/windows/desktop/aa383751%28v=vs.85%29.aspx#DWORD_PTR) and [ULONG_PTR](https://msdn.microsoft.com/en-us/library/windows/desktop/aa383751%28v=vs.85%29.aspx#ULONG_PTR). MinGW compiler produces warning when NULL is used for DWORD_PTR.