### PR TITLE
support xml:lang in release notes

### DIFF
--- a/src/appcast.h
+++ b/src/appcast.h
@@ -46,6 +46,9 @@ struct Appcast
     /// URL of the release notes page
     std::string ReleaseNotesURL;
 
+    /// Local Info£¬ like en, en-US, zh-CN, zh-TW, etc.
+    std::string Lang;
+
     /// URL to launch in web browser (instead of downloading update ourselves)
     std::string WebBrowserURL;
 
@@ -76,7 +79,7 @@ struct Appcast
 
         @param xml Appcast feed data.
      */
-    static Appcast Load(const std::string& xml);
+    static Appcast Load(const std::string& xml, const std::string& lang);
 
     /// Returns true if the struct constains valid data.
     bool IsValid() const { return !Version.empty(); }

--- a/src/updatechecker.cpp
+++ b/src/updatechecker.cpp
@@ -232,7 +232,7 @@ void UpdateChecker::Run()
         StringDownloadSink appcast_xml;
         DownloadFile(url, &appcast_xml, GetAppcastDownloadFlags());
 
-        Appcast appcast = Appcast::Load(appcast_xml.data);
+        Appcast appcast = Appcast::Load(appcast_xml.data, Settings::GetLanguage().lang);
 
         Settings::WriteConfigValue("LastCheckTime", time(NULL));
 


### PR DESCRIPTION
Before the fix, winsparkle only picks the first item, not picking the right language attribute set by win_sparkle_set_lang function.
