### PR TITLE
Include a copy of the MIT license in the repository

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,10 @@
+The MIT License
+===============
+
+Copyright © 2009–2015 Vaclav Slavik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+**The Software is provided “as is”, without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose and noninfringement. In no event shall the authors or copyright holders be liable for any claim, damages or other liability, whether in an action of contract, tort or otherwise, arising from, out of or in connection with the Software or the use or other dealings in the Software.**


### PR DESCRIPTION
This has two benefits:

1. It becomes easier for people browsing GitHub to see how the project is licensed. Right now you have to click through to the WinSparkle website (or else peek at one of the source files) to see which license is being used.
2. There is now a “paper trail” establishing that the project had a certain license on a certain date. This is attractive for organizations that wish to be fastidious about their use of third-party software.