### PR TITLE
Check for updates with UI and install automatically

### DIFF
--- a/include/winsparkle.h
+++ b/include/winsparkle.h
@@ -266,6 +266,16 @@ WIN_SPARKLE_API int __cdecl win_sparkle_get_update_check_interval();
 */
 WIN_SPARKLE_API time_t __cdecl win_sparkle_get_last_check_time();
 
+/// Callback type for win_sparkle_error_callback()
+typedef void (__cdecl *win_sparkle_error_callback_t)();
+
+/**
+    Set callback to be called when the updater encounters an error.
+
+    @since 0.5
+*/
+WIN_SPARKLE_API void __cdecl win_sparkle_set_error_callback(win_sparkle_error_callback_t callback);
+
 /// Callback type for win_sparkle_can_shutdown_callback()
 typedef int (__cdecl *win_sparkle_can_shutdown_callback_t)();
 
@@ -310,6 +320,39 @@ typedef void (__cdecl *win_sparkle_shutdown_request_callback_t)();
     @see win_sparkle_set_can_shutdown_callback()
 */
 WIN_SPARKLE_API void __cdecl win_sparkle_set_shutdown_request_callback(win_sparkle_shutdown_request_callback_t);
+
+/// Callback type for win_sparkle_did_not_find_update_callback()
+typedef void (__cdecl *win_sparkle_did_not_find_update_callback_t)();
+
+/**
+    Set callback to be called when the updater did not find an update.
+
+    This is useful in combination with
+    win_sparkle_check_update_with_ui_and_install() as it allows you to perform
+    some action after WinSparkle checks for updates.
+
+    @since 0.5
+
+    @see win_sparkle_did_find_update_callback()
+    @see win_sparkle_check_update_with_ui_and_install()
+*/
+WIN_SPARKLE_API void __cdecl win_sparkle_set_did_not_find_update_callback(win_sparkle_did_not_find_update_callback_t callback);
+
+/// Callback type for win_sparkle_update_cancelled_callback()
+typedef void (__cdecl *win_sparkle_update_cancelled_callback_t)();
+
+/**
+    Set callback to be called when the user cancels a download.
+
+    This is useful in combination with
+    win_sparkle_check_update_with_ui_and_install() as it allows you to perform
+    some action when the installation is interrupted.
+
+    @since 0.5
+
+    @see win_sparkle_check_update_with_ui_and_install()
+*/
+WIN_SPARKLE_API void __cdecl win_sparkle_set_update_cancelled_callback(win_sparkle_update_cancelled_callback_t callback);
 
 //@}
 

--- a/include/winsparkle.h
+++ b/include/winsparkle.h
@@ -389,6 +389,26 @@ WIN_SPARKLE_API void __cdecl win_sparkle_set_update_cancelled_callback(win_spark
 WIN_SPARKLE_API void __cdecl win_sparkle_check_update_with_ui();
 
 /**
+    Checks if an update is available, showing progress UI to the user and
+    immediately installing the update if one is available.
+
+    This is useful for the case when users should almost always use the
+    newest version of your software. When called, WinSparkle will check for
+    updates showing a progress UI to the user. If an update is found the update
+    prompt will be skipped and the update will be installed immediately.
+
+    If your application expects to do something after checking for updates you
+    may wish to use win_sparkle_set_did_not_find_update_callback() and
+    win_sparkle_set_update_cancelled_callback().
+
+    @since 0.5
+
+    @see win_sparkle_set_did_find_update_callback()
+    @see win_sparkle_set_update_cancelled_callback()
+ */
+WIN_SPARKLE_API void __cdecl win_sparkle_check_update_with_ui_and_install();
+
+/**
     Checks if an update is available.
 
     No progress UI is shown to the user when checking. If an update is

--- a/src/appcontroller.cpp
+++ b/src/appcontroller.cpp
@@ -31,9 +31,11 @@ namespace winsparkle
 
 CriticalSection ApplicationController::ms_csVars;
 
-win_sparkle_can_shutdown_callback_t     ApplicationController::ms_cbIsReadyToShutdown = NULL;
-win_sparkle_shutdown_request_callback_t ApplicationController::ms_cbRequestShutdown = NULL;
-
+win_sparkle_error_callback_t               ApplicationController::ms_cbError = NULL;
+win_sparkle_can_shutdown_callback_t        ApplicationController::ms_cbIsReadyToShutdown = NULL;
+win_sparkle_shutdown_request_callback_t    ApplicationController::ms_cbRequestShutdown = NULL;
+win_sparkle_did_not_find_update_callback_t ApplicationController::ms_cbDidNotFindUpdate = NULL;
+win_sparkle_update_cancelled_callback_t    ApplicationController::ms_cbUpdateCancelled = NULL;
 
 bool ApplicationController::IsReadyToShutdown()
 {
@@ -62,6 +64,42 @@ void ApplicationController::RequestShutdown()
     // default implementations:
 
     // nothing yet
+}
+
+void ApplicationController::NotifyUpdateError()
+{
+    {
+        CriticalSectionLocker lock(ms_csVars);
+        if ( ms_cbError )
+        {
+            (*ms_cbError)();
+            return;
+        }
+    }
+}
+
+void ApplicationController::NotifyUpdateNotFound()
+{
+    {
+        CriticalSectionLocker lock(ms_csVars);
+        if ( ms_cbDidNotFindUpdate )
+        {
+            (*ms_cbDidNotFindUpdate)();
+            return;
+        }
+    }
+}
+
+void ApplicationController::NotifyUpdateCancelled()
+{
+    {
+        CriticalSectionLocker lock(ms_csVars);
+        if ( ms_cbUpdateCancelled )
+        {
+            (*ms_cbUpdateCancelled)();
+            return;
+        }
+    }
 }
 
 

--- a/src/appcontroller.h
+++ b/src/appcontroller.h
@@ -53,9 +53,32 @@ public:
     //@}
 
     /**
+        Notifications.
+     */
+    //@{
+
+    /// Notify that an error occurred.
+    static void NotifyUpdateError();
+
+    /// Notify that an update has not been found.
+    static void NotifyUpdateNotFound();
+
+    /// Notify that an update was cancelled.
+    static void NotifyUpdateCancelled();
+
+    //@}
+
+    /**
         Behavior customizations -- callbacks.
      */
     //@{
+
+    /// Set the win_sparkle_error_callback_t function
+    static void SetErrorCallback(win_sparkle_error_callback_t callback)
+    {
+        CriticalSectionLocker lock(ms_csVars);
+        ms_cbError = callback;
+    }
 
     /// Set the win_sparkle_can_shutdown_callback_t function
     static void SetCanShutdownCallback(win_sparkle_can_shutdown_callback_t callback)
@@ -71,6 +94,20 @@ public:
         ms_cbRequestShutdown = callback;
     }
 
+    /// Set the win_sparkle_did_not_find_update_callback_t function
+    static void SetDidNotFindUpdateCallback(win_sparkle_did_not_find_update_callback_t callback)
+    {
+        CriticalSectionLocker lock(ms_csVars);
+        ms_cbDidNotFindUpdate = callback;
+    }
+
+    /// Set the win_sparkle_update_cancelled_callback_t function
+    static void SetUpdateCancelledCallback(win_sparkle_update_cancelled_callback_t callback)
+    {
+        CriticalSectionLocker lock(ms_csVars);
+        ms_cbUpdateCancelled = callback;
+    }
+
     //@}
 
 private:
@@ -79,8 +116,11 @@ private:
     // guards the variables below:
     static CriticalSection ms_csVars;
 
-    static win_sparkle_can_shutdown_callback_t     ms_cbIsReadyToShutdown;
-    static win_sparkle_shutdown_request_callback_t ms_cbRequestShutdown;
+    static win_sparkle_error_callback_t               ms_cbError;
+    static win_sparkle_can_shutdown_callback_t        ms_cbIsReadyToShutdown;
+    static win_sparkle_shutdown_request_callback_t    ms_cbRequestShutdown;
+    static win_sparkle_did_not_find_update_callback_t ms_cbDidNotFindUpdate;
+    static win_sparkle_update_cancelled_callback_t    ms_cbUpdateCancelled;
 };
 
 } // namespace winsparkle

--- a/src/dll_api.cpp
+++ b/src/dll_api.cpp
@@ -262,6 +262,15 @@ WIN_SPARKLE_API time_t __cdecl win_sparkle_get_last_check_time()
     return DEFAULT_LAST_CHECK_TIME;
 }
 
+WIN_SPARKLE_API void __cdecl win_sparkle_set_error_callback(win_sparkle_error_callback_t callback)
+{
+    try
+    {
+        ApplicationController::SetErrorCallback(callback);
+    }
+    CATCH_ALL_EXCEPTIONS
+}
+
 WIN_SPARKLE_API void __cdecl win_sparkle_set_can_shutdown_callback(win_sparkle_can_shutdown_callback_t callback)
 {
     try
@@ -276,6 +285,24 @@ WIN_SPARKLE_API void __cdecl win_sparkle_set_shutdown_request_callback(win_spark
     try
     {
         ApplicationController::SetShutdownRequestCallback(callback);
+    }
+    CATCH_ALL_EXCEPTIONS
+}
+
+WIN_SPARKLE_API void __cdecl win_sparkle_set_did_not_find_update_callback(win_sparkle_did_not_find_update_callback_t callback)
+{
+    try
+    {
+        ApplicationController::SetDidNotFindUpdateCallback(callback);
+    }
+    CATCH_ALL_EXCEPTIONS
+}
+
+WIN_SPARKLE_API void __cdecl win_sparkle_set_update_cancelled_callback(win_sparkle_update_cancelled_callback_t callback)
+{
+    try
+    {
+        ApplicationController::SetUpdateCancelledCallback(callback);
     }
     CATCH_ALL_EXCEPTIONS
 }

--- a/src/dll_api.cpp
+++ b/src/dll_api.cpp
@@ -325,6 +325,20 @@ WIN_SPARKLE_API void __cdecl win_sparkle_check_update_with_ui()
     CATCH_ALL_EXCEPTIONS
 }
 
+WIN_SPARKLE_API void __cdecl win_sparkle_check_update_with_ui_and_install()
+{
+    try
+    {
+        // Initialize UI thread and show progress indicator.
+        UI::ShowCheckingUpdates();
+
+        // Then run the actual check in the background.
+        UpdateChecker *check = new ManualAutoInstallUpdateChecker();
+        check->Start();
+    }
+    CATCH_ALL_EXCEPTIONS
+}
+
 WIN_SPARKLE_API void __cdecl win_sparkle_check_update_without_ui()
 {
     try

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -154,6 +154,7 @@ struct EventPayload
     Appcast      appcast;
     size_t       sizeDownloaded, sizeTotal;
     std::wstring updateFile;
+    bool         installAutomatically;
 };
 
 
@@ -411,11 +412,11 @@ public:
     // changes state into "checking for updates"
     void StateCheckingUpdates();
     // change state into "no updates found"
-    void StateNoUpdateFound();
+    void StateNoUpdateFound(bool installAutomatically);
     // change state into "update error"
     void StateUpdateError();
     // change state into "a new version is available"
-    void StateUpdateAvailable(const Appcast& info);
+    void StateUpdateAvailable(const Appcast& info, bool installAutomatically);
     // change state into "downloading update"
     void StateDownloading();
     // update download progress
@@ -466,6 +467,8 @@ private:
     std::string m_installerArguments;
     // downloader (only valid between OnInstall and OnUpdateDownloaded)
     UpdateDownloader* m_downloader;
+    // whether the update should be installed without prompting the user
+    bool m_installAutomatically;
     // whether an error occurred (used to properly call NotifyUpdateCancelled)
     bool m_errorOccurred;
 
@@ -478,6 +481,7 @@ UpdateDialog::UpdateDialog()
     : m_timer(this),
       m_downloader(NULL)
 {
+    m_installAutomatically = false;
     m_errorOccurred = false;
 
     m_heading = new wxStaticText(this, wxID_ANY, "");
@@ -727,9 +731,17 @@ void UpdateDialog::StateCheckingUpdates()
 }
 
 
-void UpdateDialog::StateNoUpdateFound()
+void UpdateDialog::StateNoUpdateFound(bool installAutomatically)
 {
+    m_installAutomatically = installAutomatically;
+
     ApplicationController::NotifyUpdateNotFound();
+
+    if ( m_installAutomatically )
+    {
+        Close();
+        return;
+    }
 
     LayoutChangesGuard guard(this);
 
@@ -795,9 +807,17 @@ void UpdateDialog::StateUpdateError()
 
 
 
-void UpdateDialog::StateUpdateAvailable(const Appcast& info)
+void UpdateDialog::StateUpdateAvailable(const Appcast& info, bool installAutomatically)
 {
     m_appcast = info;
+    m_installAutomatically = installAutomatically;
+
+    if ( installAutomatically )
+    {
+        wxCommandEvent nullEvent;
+        OnInstall(nullEvent);
+        return;
+    }
 
     const bool showRelnotes = !info.ReleaseNotesURL.empty() || !info.Description.empty();
 
@@ -912,6 +932,13 @@ void UpdateDialog::StateUpdateDownloaded(const std::wstring& updateFile, const s
 
     m_updateFile = updateFile;
     m_installerArguments = installerArguments;
+
+    if ( m_installAutomatically )
+    {
+        wxCommandEvent nullEvent;
+        OnRunInstaller(nullEvent);
+        return;
+    }
 
     LayoutChangesGuard guard(this);
 
@@ -1283,10 +1310,13 @@ void App::OnShowCheckingUpdates(wxThreadEvent&)
 }
 
 
-void App::OnNoUpdateFound(wxThreadEvent&)
+void App::OnNoUpdateFound(wxThreadEvent& event)
 {
     if ( m_win )
-        m_win->StateNoUpdateFound();
+    {
+        EventPayload payload(event.GetPayload<EventPayload>());
+        m_win->StateNoUpdateFound(payload.installAutomatically);
+    }
 }
 
 
@@ -1320,7 +1350,7 @@ void App::OnUpdateAvailable(wxThreadEvent& event)
     InitWindow();
 
     EventPayload payload(event.GetPayload<EventPayload>());
-    m_win->StateUpdateAvailable(payload.appcast);
+    m_win->StateUpdateAvailable(payload.appcast, payload.installAutomatically);
 
     ShowWindow();
 }
@@ -1445,23 +1475,26 @@ void UI::ShutDown()
 
 
 /*static*/
-void UI::NotifyNoUpdates()
+void UI::NotifyNoUpdates(bool installAutomatically)
 {
     UIThreadAccess uit;
+    EventPayload payload;
+    payload.installAutomatically = installAutomatically;
 
     if ( !uit.IsRunning() )
         return;
 
-    uit.App().SendMsg(MSG_NO_UPDATE_FOUND);
+    uit.App().SendMsg(MSG_NO_UPDATE_FOUND, &payload);
 }
 
 
 /*static*/
-void UI::NotifyUpdateAvailable(const Appcast& info)
+void UI::NotifyUpdateAvailable(const Appcast& info, bool installAutomatically)
 {
     UIThreadAccess uit;
     EventPayload payload;
     payload.appcast = info;
+    payload.installAutomatically = installAutomatically;
     uit.App().SendMsg(MSG_UPDATE_AVAILABLE, &payload);
 }
 

--- a/src/ui.h
+++ b/src/ui.h
@@ -60,7 +60,7 @@ public:
         (i.e. the user is manually checking for updates), "no updates found"
         message is shown. Otherwise, does nothing.
      */
-    static void NotifyNoUpdates();
+    static void NotifyNoUpdates(bool installAutomatically);
 
     /**
         Notifies the UI that there was an error retrieving updates.
@@ -76,7 +76,7 @@ public:
 
         If the UI thread isn't running yet, it will be launched.
      */
-    static void NotifyUpdateAvailable(const Appcast& info);
+    static void NotifyUpdateAvailable(const Appcast& info, bool installAutomatically);
 
     /**
         Notifies the UI about download progress.

--- a/src/updatechecker.cpp
+++ b/src/updatechecker.cpp
@@ -217,7 +217,6 @@ UpdateChecker::UpdateChecker(): Thread("WinSparkle updates check")
 {
 }
 
-
 void UpdateChecker::Run()
 {
     // no initialization to do, so signal readiness immediately
@@ -243,18 +242,18 @@ void UpdateChecker::Run()
         if ( !appcast.IsValid() || CompareVersions(currentVersion, appcast.Version) >= 0 )
         {
             // The same or newer version is already installed.
-            UI::NotifyNoUpdates();
+            UI::NotifyNoUpdates(ShouldAutomaticallyInstall());
             return;
         }
 
         // Check if the user opted to ignore this particular version.
         if ( ShouldSkipUpdate(appcast) )
         {
-            UI::NotifyNoUpdates();
+            UI::NotifyNoUpdates(ShouldAutomaticallyInstall());
             return;
         }
 
-        UI::NotifyUpdateAvailable(appcast);
+        UI::NotifyUpdateAvailable(appcast, ShouldAutomaticallyInstall());
     }
     catch ( ... )
     {

--- a/src/updatechecker.h
+++ b/src/updatechecker.h
@@ -66,6 +66,9 @@ protected:
     /// Should give version be ignored?
     virtual bool ShouldSkipUpdate(const Appcast& appcast) const;
 
+    /// Should we install the update or prompt the user for options first?
+    virtual bool ShouldAutomaticallyInstall() const { return false; }
+
 protected:
     virtual void Run();
     virtual bool IsJoinable() const { return false; }
@@ -85,6 +88,21 @@ protected:
     virtual int GetAppcastDownloadFlags() const;
     virtual bool ShouldSkipUpdate(const Appcast& appcast) const;
 };
+
+
+/**
+    Update checker used to automatically install updates when found.
+ */
+class ManualAutoInstallUpdateChecker : public ManualUpdateChecker
+{
+public:
+    /// Creates checker thread.
+    ManualAutoInstallUpdateChecker() : ManualUpdateChecker() {}
+
+protected:
+    virtual bool ShouldAutomaticallyInstall() const { return true; };
+};
+
 
 } // namespace winsparkle
 


### PR DESCRIPTION
This PR adds the ability for a program to check for updates and automatically install them if available. This functionality is present in the Mac version of Sparkle as of https://github.com/sparkle-project/Sparkle/pull/620.

Once `win_sparkle_check_update_with_ui_and_install()` is called, the following cases may occur:

- An error occurs, in which case the `win_sparkle_error_callback_t` is called
- The application is up to date, in which case the `win_sparkle_did_not_find_update_callback_t` is called
- The application is not up to date. The update begins to download automatically, then...
   - If the user interrupts the download (i.e.., clicks the cancel button or closes the update dialog) the `win_sparkle_update_cancelled_callback_t` is called
   - If the update completes, `win_sparkle_shutdown_request_callback_t` is called and the newly-downloaded installer runs

CC @mlogan @BKcore