### PR TITLE
Callback "did find update"

### DIFF
--- a/include/winsparkle.h
+++ b/include/winsparkle.h
@@ -321,6 +321,23 @@ typedef void (__cdecl *win_sparkle_shutdown_request_callback_t)();
 */
 WIN_SPARKLE_API void __cdecl win_sparkle_set_shutdown_request_callback(win_sparkle_shutdown_request_callback_t);
 
+/// Callback type for win_sparkle_did_find_update_callback()
+typedef void(__cdecl *win_sparkle_did_find_update_callback_t)();
+
+/**
+    Set callback to be called when the updater did find an update.
+
+    This is useful in combination with
+    win_sparkle_check_update_with_ui_and_install() as it allows you to perform
+    some action after WinSparkle checks for updates.
+
+    @since 0.5
+
+    @see win_sparkle_did_not_find_update_callback()
+    @see win_sparkle_check_update_with_ui_and_install()
+*/
+WIN_SPARKLE_API void __cdecl win_sparkle_set_did_find_update_callback(win_sparkle_did_find_update_callback_t callback);
+
 /// Callback type for win_sparkle_did_not_find_update_callback()
 typedef void (__cdecl *win_sparkle_did_not_find_update_callback_t)();
 

--- a/src/appcontroller.cpp
+++ b/src/appcontroller.cpp
@@ -34,6 +34,7 @@ CriticalSection ApplicationController::ms_csVars;
 win_sparkle_error_callback_t               ApplicationController::ms_cbError = NULL;
 win_sparkle_can_shutdown_callback_t        ApplicationController::ms_cbIsReadyToShutdown = NULL;
 win_sparkle_shutdown_request_callback_t    ApplicationController::ms_cbRequestShutdown = NULL;
+win_sparkle_did_find_update_callback_t     ApplicationController::ms_cbDidFindUpdate = NULL;
 win_sparkle_did_not_find_update_callback_t ApplicationController::ms_cbDidNotFindUpdate = NULL;
 win_sparkle_update_cancelled_callback_t    ApplicationController::ms_cbUpdateCancelled = NULL;
 
@@ -73,6 +74,18 @@ void ApplicationController::NotifyUpdateError()
         if ( ms_cbError )
         {
             (*ms_cbError)();
+            return;
+        }
+    }
+}
+
+void ApplicationController::NotifyUpdateFound()
+{
+    {
+        CriticalSectionLocker lock(ms_csVars);
+        if (ms_cbDidFindUpdate)
+        {
+            (*ms_cbDidFindUpdate)();
             return;
         }
     }

--- a/src/appcontroller.h
+++ b/src/appcontroller.h
@@ -60,6 +60,9 @@ public:
     /// Notify that an error occurred.
     static void NotifyUpdateError();
 
+    /// Notify that an update has been found.
+    static void NotifyUpdateFound();
+
     /// Notify that an update has not been found.
     static void NotifyUpdateNotFound();
 
@@ -94,6 +97,13 @@ public:
         ms_cbRequestShutdown = callback;
     }
 
+    /// Set the win_sparkle_did_find_update_callback_t function
+    static void SetDidFindUpdateCallback(win_sparkle_did_find_update_callback_t callback)
+    {
+        CriticalSectionLocker lock(ms_csVars);
+        ms_cbDidFindUpdate = callback;
+    }
+
     /// Set the win_sparkle_did_not_find_update_callback_t function
     static void SetDidNotFindUpdateCallback(win_sparkle_did_not_find_update_callback_t callback)
     {
@@ -119,6 +129,7 @@ private:
     static win_sparkle_error_callback_t               ms_cbError;
     static win_sparkle_can_shutdown_callback_t        ms_cbIsReadyToShutdown;
     static win_sparkle_shutdown_request_callback_t    ms_cbRequestShutdown;
+    static win_sparkle_did_find_update_callback_t     ms_cbDidFindUpdate;
     static win_sparkle_did_not_find_update_callback_t ms_cbDidNotFindUpdate;
     static win_sparkle_update_cancelled_callback_t    ms_cbUpdateCancelled;
 };

--- a/src/dll_api.cpp
+++ b/src/dll_api.cpp
@@ -289,6 +289,15 @@ WIN_SPARKLE_API void __cdecl win_sparkle_set_shutdown_request_callback(win_spark
     CATCH_ALL_EXCEPTIONS
 }
 
+WIN_SPARKLE_API void __cdecl win_sparkle_set_did_find_update_callback(win_sparkle_did_find_update_callback_t callback)
+{
+    try
+    {
+        ApplicationController::SetDidFindUpdateCallback(callback);
+    }
+    CATCH_ALL_EXCEPTIONS
+}
+
 WIN_SPARKLE_API void __cdecl win_sparkle_set_did_not_find_update_callback(win_sparkle_did_not_find_update_callback_t callback)
 {
     try

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -816,6 +816,8 @@ void UpdateDialog::StateUpdateAvailable(const Appcast& info, bool installAutomat
     m_appcast = info;
     m_installAutomatically = installAutomatically;
 
+    ApplicationController::NotifyUpdateFound();
+    
     if ( installAutomatically )
     {
         wxCommandEvent nullEvent;


### PR DESCRIPTION
Implement the callback "win_sparkle_set_did_find_update_callback" that is called when an update have been found by WinSparkle, in order to let the application UI do some other notification for the user if needed.

It follows the Mac Sparkle version : http://sparkle-project.org/documentation/customization/
*(void)updater:(SUUpdater *)updater didFindValidUpdate:(SUAppcastItem *)update;
(void)updaterDidNotFindUpdate:(SUUpdater *)update;*

*The naming was done using the documentation reference from "win_sparkle_set_did_not_find_update_callback()" that says "@see win_sparkle_did_find_update_callback()"*