### PR TITLE
Always make call into "did not find update" callback

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -739,9 +739,7 @@ void UpdateDialog::StateNoUpdateFound(bool installAutomatically)
 {
     m_installAutomatically = installAutomatically;
 
-    ApplicationController::NotifyUpdateNotFound();
-
-    if ( m_installAutomatically )
+       if ( m_installAutomatically )
     {
         Close();
         return;
@@ -1485,6 +1483,7 @@ void UI::NotifyNoUpdates(bool installAutomatically)
     EventPayload payload;
     payload.installAutomatically = installAutomatically;
 
+    ApplicationController::NotifyUpdateNotFound();
     if ( !uit.IsRunning() )
         return;
 


### PR DESCRIPTION
Updates to ui.cpp

Always make call into "did not find update" callback

Previously, win_sparkle_set_did_not_find_update_callback would not get called if win_sparkle_check_update_without_ui() was used.  Made changes so that callback would get called when win_sparkle_check_update_with_ui_and_install(), win_sparkle_check_update_without_ui(), etc are used.