### PR TITLE
Make installerArguments work with MSI.

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -57,6 +57,7 @@
 #include <exdisp.h>
 #include <mshtml.h>
 #include <commctrl.h>
+#include <shellapi.h>
 
 
 #if !wxCHECK_VERSION(2,9,0)
@@ -695,17 +696,22 @@ void UpdateDialog::OnRunInstaller(wxCommandEvent&)
 
 bool UpdateDialog::RunInstaller()
 {
-    if (m_installerArguments.empty()) 
+    std::wstring wArgs;
+
+    SHELLEXECUTEINFO sei;
+    ::ZeroMemory(&sei, sizeof(SHELLEXECUTEINFO));
+    sei.cbSize = sizeof(SHELLEXECUTEINFO);
+    sei.lpFile = m_updateFile.t_str();
+    sei.nShow = SW_SHOWDEFAULT;
+    sei.fMask = SEE_MASK_FLAG_NO_UI;	// We display our own dialog box on error
+
+    if (! m_installerArguments.empty())
     {
-        // keep old way of calling updater to not accidentally break any existing code
-        return wxLaunchDefaultApplication(m_updateFile);
-    } 
-    else 
-    {
-        // wxExecute() returns a process id, or zero on failure
-        long processId = wxExecute(m_updateFile + " " + m_installerArguments);
-        return processId != 0;
+        wArgs = AnsiToWide(m_installerArguments);
+        sei.lpParameters = wArgs.c_str();
     }
+
+    return ::ShellExecuteEx(&sei) ? true : false;
 }
 
 void UpdateDialog::SetMessage(const wxString& text, int width)


### PR DESCRIPTION
The [documentation](https://github.com/vslavik/winsparkle/wiki/Appcast-Feeds#installer-arguments) says that you can use <sparkle:installerArguments>="/passive" when installing an MSI file. But this doesn't actually work.

WinSparkle uses wxExecute() instead of wxLaunchDefaultApplication() when installer arguments are supplied in the appcast. But wxExecute() ultimately calls win32's CreateProcess(), which expects an executable not a MSI file.

This patch copies wxLaunchDefaultApplication() to use win32's ShellExecuteEx(), which handles both executables and MSI files.
