### PR TITLE
Fix WinSparkle.Targets

### DIFF
--- a/WinSparkle.Targets
+++ b/WinSparkle.Targets
@@ -3,7 +3,7 @@
          ToolsVersion="4.0">
 
   <PropertyGroup>
-    <GettextBinDir>$(SolutionDir)\packages\Gettext.Tools.0.19.7.001\tools\bin\</GettextBinDir>
+    <GettextBinDir>"$(SolutionDir)"\packages\Gettext.Tools.0.19.7.001\tools\bin\</GettextBinDir>
     <Msgfmt>$(GettextBinDir)msgfmt.exe -c</Msgfmt>
   </PropertyGroup>
 


### PR DESCRIPTION
WinSparkle can't be built if the solution path has blanks in it. This is the
case, for example, if your WinSparkle project folder sits in the Visual Studio
default location for projects which happens to have "Visual Studio 2013" in it,
for example, if you are using Visual Studio 2013.

This commit encloses the solution path in double quotes to deal with those
blanks.

Fixes #90