### PR TITLE
Update Readme.md (missing MSVC mentions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Check the sources out and initialize the submodules:
 To compile the library, just open `WinSparkle.sln` (or the one corresponding to
 your compiler version) solution and build it.
 
-At the moment, projects for Visual C++ 2008, 2010 and 2012 are provided, so
+At the moment, projects for Visual C++ 2008, 2010, 2012, 2013 and 2015 are provided, so
 you'll need that (Express edition suffices). In principle, there's nothing in
 the code preventing it from being compiled by other compilers.
 


### PR DESCRIPTION
Just a very small change: The available project versions of MSVC in Readme.md did not correspond to the ones available in the repo.