### PR TITLE
WinSparkle-2010.vcxproj - add missing WinSparkle.Targets for building…

### DIFF
--- a/3rdparty/expat/lib/xmlparse.c
+++ b/3rdparty/expat/lib/xmlparse.c
@@ -1694,13 +1694,15 @@ XML_GetBuffer(XML_Parser parser, int len)
 
   if (len > bufferLim - bufferEnd) {
     int neededSize = len + (int)(bufferEnd - bufferPtr);
+#ifdef XML_CONTEXT_BYTES
+    int keep;
+#endif
     if (neededSize < 0) {
       errorCode = XML_ERROR_NO_MEMORY;
       return NULL;
     }
 #ifdef XML_CONTEXT_BYTES
-    int keep = (int)(bufferPtr - buffer);
-
+    keep = (int)(bufferPtr - buffer);
     if (keep > XML_CONTEXT_BYTES)
       keep = XML_CONTEXT_BYTES;
     neededSize += keep;

--- a/WinSparkle-2010.vcxproj
+++ b/WinSparkle-2010.vcxproj
@@ -211,6 +211,13 @@
       <Project>{499a5238-5aac-5fd3-8902-819d787108a5}</Project>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="WinSparkle.Targets">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="WinSparkle.targets" />
+  </ImportGroup>
 </Project>


### PR DESCRIPTION
… translation resources

xmlparse.c, XML_GetBuffer() - move variable declaration to the beginning of the block.