### PR TITLE
Get the file URL from the response

### DIFF
--- a/src/download.cpp
+++ b/src/download.cpp
@@ -99,10 +99,10 @@ bool GetHttpHeader(HINTERNET handle, DWORD whatToGet, DWORD& output)
            ) == TRUE;
 }
 
-std::wstring GetURLFileName(const URL_COMPONENTSA& urlc)
+std::wstring GetURLFileName(const char *url)
 {
-    const char *lastSlash = strrchr(urlc.lpszUrlPath, '/');
-    const std::string fn(lastSlash ? lastSlash + 1 : urlc.lpszUrlPath);
+    const char *lastSlash = strrchr(url, '/');
+    const std::string fn(lastSlash ? lastSlash + 1 : url);
     return AnsiToWide(fn);
 }
 
@@ -206,7 +206,25 @@ void DownloadFile(const std::string& url, IDownloadSink *sink, int flags)
 
     if ( !filename_set )
     {
-        sink->SetFilename(GetURLFileName(urlc));
+        char *optionurl;
+        DWORD ousize = 0;
+        InternetQueryOptionA(conn, INTERNET_OPTION_URL, nullptr, &ousize);
+        if (GetLastError() == ERROR_INSUFFICIENT_BUFFER)
+        {
+            optionurl = new char[ousize];
+            if ( InternetQueryOptionA(conn, INTERNET_OPTION_URL, optionurl, &ousize) )
+                sink->SetFilename(GetURLFileName(optionurl));
+            else
+                sink->SetFilename(GetURLFileName(urlc.lpszUrlPath));
+            
+            delete[] optionurl;
+        }
+        else
+        {
+            sink->SetFilename(GetURLFileName(urlc.lpszUrlPath));
+        }
+        
+        optionurl = NULL;
     }
 
     // Download the data:


### PR DESCRIPTION
This should fix the issue in #109 

The provided PR will attempt to get the URL from `INTERNET_OPTION_URL` by querying the response. This should prevent issues where the URL in an AppCast file points to a location which is being redirected.