### PR TITLE
CE changes for Winsparkle DLL

### DIFF
--- a/src/dll_api.cpp
+++ b/src/dll_api.cpp
@@ -46,70 +46,35 @@ extern "C"
 
 WIN_SPARKLE_API void __cdecl win_sparkle_init()
 {
-    try
-    {
-        // finish initialization
-        if (!Settings::GetLanguage().IsOk())
-        {
-            LANGID lang = 0;
-            if (IsWindowsVistaOrGreater())
-            {
-                auto f_GetThreadUILanguage = LOAD_DYNAMIC_FUNC(GetThreadUILanguage, kernel32);
-                if (f_GetThreadUILanguage)
-                    lang = f_GetThreadUILanguage();
-            }
-            if (PRIMARYLANGID(lang) == 0)
-            {
-                lang = LANGIDFROMLCID(GetThreadLocale());
-            }
-            if (PRIMARYLANGID(lang) != 0)
-                Settings::SetLanguage(lang);
-        }
+	try
+	{
+		// finish initialization
+		if (!Settings::GetLanguage().IsOk())
+		{
+			LANGID lang = 0;
+			if (IsWindowsVistaOrGreater())
+			{
+				auto f_GetThreadUILanguage = LOAD_DYNAMIC_FUNC(GetThreadUILanguage, kernel32);
+				if (f_GetThreadUILanguage)
+					lang = f_GetThreadUILanguage();
+			}
+			if (PRIMARYLANGID(lang) == 0)
+			{
+				lang = LANGIDFROMLCID(GetThreadLocale());
+			}
+			if (PRIMARYLANGID(lang) != 0)
+				Settings::SetLanguage(lang);
+		}
 
-        // first things first
-        UpdateDownloader::CleanLeftovers();
+		// first things first
+		UpdateDownloader::CleanLeftovers();
 
-        // check for updates
-        bool checkUpdates;
-        if ( Settings::ReadConfigValue("CheckForUpdates", checkUpdates) )
-        {
-            if ( checkUpdates )
-            {
-                static const time_t ONE_DAY = 60*60*24;
-
-                time_t lastCheck = 0;
-                Settings::ReadConfigValue("LastCheckTime", lastCheck);
-                const time_t currentTime = time(NULL);
-
-                // Only check for updates in reasonable intervals:
-                const int interval = win_sparkle_get_update_check_interval();
-                if ( currentTime - lastCheck >= interval )
-                {
-                    // Run the check in background. Only show UI if updates
-                    // are available.
-                    UpdateChecker *check = new UpdateChecker();
-                    check->Start();
-                }
-            }
-        }
-        else // not yet configured
-        {
-            bool didRunOnce;
-            Settings::ReadConfigValue("DidRunOnce", didRunOnce, false);
-            if ( !didRunOnce )
-            {
-                // Do nothing on the first execution of the app, for better
-                // first-time impression.
-                Settings::WriteConfigValue("DidRunOnce", true);
-            }
-            else
-            {
-                // Only when the app is launched for the second time, ask the
-                // user for their permission to check for updates.
-                UI::AskForPermission();
-            }
-        }
-    }
+		// Run the check in background. Only show UI if updates
+		// are available.
+		UpdateChecker *check = new UpdateChecker();
+		check->Start();
+	}
+	
     CATCH_ALL_EXCEPTIONS
 }
 

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -320,12 +320,10 @@ protected:
 WinSparkleDialog::WinSparkleDialog()
     : wxDialog(NULL, wxID_ANY, _("Software Update"),
                wxDefaultPosition, wxDefaultSize,
-               wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxDIALOG_NO_PARENT)
+		       wxDEFAULT_DIALOG_STYLE | wxDIALOG_NO_PARENT)
 {
     wxSize dpi = wxClientDC(this).GetPPI();
     m_scaleFactor = dpi.y / 96.0;
-
-    SetIcon(LoadNamedIcon(UI::GetDllHINSTANCE(), L"UpdateAvailable", GetSystemMetrics(SM_CXSMICON)));
 
     wxSizer *topSizer = new wxBoxSizer(wxHORIZONTAL);
 
@@ -388,7 +386,6 @@ void WinSparkleDialog::SetHeadingFont(wxWindow *win)
         // 9pt is base font, 12pt is for "Main instructions". See
         // http://msdn.microsoft.com/en-us/library/aa511282%28v=MSDN.10%29.aspx
         f.SetPointSize(f.GetPointSize() + 3);
-        win->SetForegroundColour(wxColour(0x00, 0x33, 0x99));
     }
     else // Windows XP/2000
     {
@@ -543,7 +540,7 @@ UpdateDialog::UpdateDialog()
                           );
     m_updateButtonsSizer->Add
                           (
-                            m_installButton = new wxButton(this, ID_INSTALL, _("Install update")),
+                            m_installButton = new wxButton(this, ID_INSTALL, _("Download")),
                             wxSizerFlags()
                           );
     m_buttonSizer->Add(m_updateButtonsSizer, wxSizerFlags(1));
@@ -1003,10 +1000,14 @@ void UpdateDialog::ShowReleaseNotes(const Appcast& info)
 
     if( !info.ReleaseNotesURL.empty() )
     {
-        m_webBrowser->Navigate
+		VARIANT varFlags;
+		varFlags.vt = VT_I4;
+		varFlags.llVal = (navNoHistory | navNoReadFromCache | navNoWriteToCache);
+
+		m_webBrowser->Navigate
                       (
                           wxBasicString(info.ReleaseNotesURL),
-                          NULL,  // Flags
+						  &varFlags,  // Flags
                           NULL,  // TargetFrameName
                           NULL,  // PostData
                           NULL   // Headers
@@ -1071,7 +1072,7 @@ void UpdateDialog::ShowReleaseNotes(const Appcast& info)
         }
     }
 
-    SetWindowStyleFlag(wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER);
+	SetWindowStyleFlag(wxDEFAULT_DIALOG_STYLE);
 }
 
 

--- a/src/updatechecker.cpp
+++ b/src/updatechecker.cpp
@@ -36,6 +36,7 @@
 #include <vector>
 #include <cstdlib>
 #include <algorithm>
+#include <winsparkle.h>
 
 using namespace std;
 
@@ -219,52 +220,80 @@ UpdateChecker::UpdateChecker(): Thread("WinSparkle updates check")
 
 void UpdateChecker::Run()
 {
-    // no initialization to do, so signal readiness immediately
-    SignalReady();
+	while (1)
+	{
+		// no initialization to do, so signal readiness immediately
+ 		SignalReady();
 
-    try
-    {
-        const std::string url = Settings::GetAppcastURL();
-        if ( url.empty() )
-            throw std::runtime_error("Appcast URL not specified.");
-        CheckForInsecureURL(url, "appcast feed");
+		bool checkUpdates;
+		if (Settings::ReadConfigValue("CheckForUpdates", checkUpdates))
+		{
+			if (checkUpdates)
+			{
+				static const time_t ONE_DAY = 60 * 60 * 24;
 
-        StringDownloadSink appcast_xml;
-        DownloadFile(url, &appcast_xml, this, GetAppcastDownloadFlags());
+				time_t lastCheck = 0;
+				Settings::ReadConfigValue("LastCheckTime", lastCheck);
+				const time_t currentTime = time(NULL);
 
-        Appcast appcast = Appcast::Load(appcast_xml.data);
-        if (!appcast.ReleaseNotesURL.empty())
-            CheckForInsecureURL(appcast.ReleaseNotesURL, "release notes");
-        if (!appcast.DownloadURL.empty())
-            CheckForInsecureURL(appcast.DownloadURL, "update file");
+				// Only check for updates in reasonable intervals:
+				const int interval = win_sparkle_get_update_check_interval();
+				if (currentTime - lastCheck >= interval)
+				{
+					UpdateCheckWorker();
+				}
+			}
+		}
+		// Check every 5 minutes
+		Sleep(300000);
+	}
+}
 
-        Settings::WriteConfigValue("LastCheckTime", time(NULL));
+void UpdateChecker::UpdateCheckWorker()
+{
+	try
+	{
+		const std::string url = Settings::GetAppcastURL();
+		if (url.empty())
+			throw std::runtime_error("Appcast URL not specified.");
+		CheckForInsecureURL(url, "appcast feed");
 
-        const std::string currentVersion =
-                WideToAnsi(Settings::GetAppBuildVersion());
+		StringDownloadSink appcast_xml;
+		DownloadFile(url, &appcast_xml, this, GetAppcastDownloadFlags());
 
-        // Check if our version is out of date.
-        if ( !appcast.IsValid() || CompareVersions(currentVersion, appcast.Version) >= 0 )
-        {
-            // The same or newer version is already installed.
-            UI::NotifyNoUpdates(ShouldAutomaticallyInstall());
-            return;
-        }
+		Appcast appcast = Appcast::Load(appcast_xml.data);
+		if (!appcast.ReleaseNotesURL.empty())
+			CheckForInsecureURL(appcast.ReleaseNotesURL, "release notes");
+		if (!appcast.DownloadURL.empty())
+			CheckForInsecureURL(appcast.DownloadURL, "update file");
 
-        // Check if the user opted to ignore this particular version.
-        if ( ShouldSkipUpdate(appcast) )
-        {
-            UI::NotifyNoUpdates(ShouldAutomaticallyInstall());
-            return;
-        }
+		Settings::WriteConfigValue("LastCheckTime", time(NULL));
 
-        UI::NotifyUpdateAvailable(appcast, ShouldAutomaticallyInstall());
-    }
-    catch ( ... )
-    {
-        UI::NotifyUpdateError();
-        throw;
-    }
+		const std::string currentVersion =
+			WideToAnsi(Settings::GetAppBuildVersion());
+
+		// Check if our version is out of date.
+		if (!appcast.IsValid() || CompareVersions(currentVersion, appcast.Version) >= 0)
+		{
+			// The same or newer version is already installed.
+			UI::NotifyNoUpdates(ShouldAutomaticallyInstall());
+			return;
+		}
+
+		// Check if the user opted to ignore this particular version.
+		if (ShouldSkipUpdate(appcast))
+		{
+			UI::NotifyNoUpdates(ShouldAutomaticallyInstall());
+			return;
+		}
+
+		UI::NotifyUpdateAvailable(appcast, ShouldAutomaticallyInstall());
+	}
+	catch (...)
+	{
+		UI::NotifyUpdateError();
+		throw;
+	}
 }
 
 bool UpdateChecker::ShouldSkipUpdate(const Appcast& appcast) const
@@ -302,4 +331,11 @@ bool ManualUpdateChecker::ShouldSkipUpdate(const Appcast&) const
     return false;
 }
 
+void ManualUpdateChecker::Run()
+{
+	// no initialization to do, so signal readiness immediately
+	SignalReady();
+
+	UpdateCheckWorker();
+}
 } // namespace winsparkle

--- a/src/updatechecker.h
+++ b/src/updatechecker.h
@@ -70,7 +70,8 @@ protected:
     virtual bool ShouldAutomaticallyInstall() const { return false; }
 
 protected:
-    virtual void Run();
+	void Run();
+	virtual void UpdateCheckWorker();
     virtual bool IsJoinable() const { return false; }
 };
 
@@ -87,6 +88,7 @@ public:
 protected:
     virtual int GetAppcastDownloadFlags() const;
     virtual bool ShouldSkipUpdate(const Appcast& appcast) const;
+	void Run();
 };
 
 


### PR DESCRIPTION
UX changes, don't use caching for loading release notes, check for updates in the background.