### PR TITLE
Add background checking for updates

### DIFF
--- a/src/dll_api.cpp
+++ b/src/dll_api.cpp
@@ -69,47 +69,12 @@ WIN_SPARKLE_API void __cdecl win_sparkle_init()
         // first things first
         UpdateDownloader::CleanLeftovers();
 
-        // check for updates
-        bool checkUpdates;
-        if ( Settings::ReadConfigValue("CheckForUpdates", checkUpdates) )
-        {
-            if ( checkUpdates )
-            {
-                static const time_t ONE_DAY = 60*60*24;
-
-                time_t lastCheck = 0;
-                Settings::ReadConfigValue("LastCheckTime", lastCheck);
-                const time_t currentTime = time(NULL);
-
-                // Only check for updates in reasonable intervals:
-                const int interval = win_sparkle_get_update_check_interval();
-                if ( currentTime - lastCheck >= interval )
-                {
-                    // Run the check in background. Only show UI if updates
-                    // are available.
-                    UpdateChecker *check = new UpdateChecker();
-                    check->Start();
-                }
-            }
-        }
-        else // not yet configured
-        {
-            bool didRunOnce;
-            Settings::ReadConfigValue("DidRunOnce", didRunOnce, false);
-            if ( !didRunOnce )
-            {
-                // Do nothing on the first execution of the app, for better
-                // first-time impression.
-                Settings::WriteConfigValue("DidRunOnce", true);
-            }
-            else
-            {
-                // Only when the app is launched for the second time, ask the
-                // user for their permission to check for updates.
-                UI::AskForPermission();
-            }
-        }
+        // Run the check in background. Only show UI if updates
+        // are available.
+        UpdateChecker *check = new UpdateChecker();
+        check->Start();
     }
+    
     CATCH_ALL_EXCEPTIONS
 }
 

--- a/src/updatechecker.h
+++ b/src/updatechecker.h
@@ -71,6 +71,7 @@ protected:
 
 protected:
     virtual void Run();
+    virtual void UpdateCheckWorker();
     virtual bool IsJoinable() const { return false; }
 };
 
@@ -87,6 +88,7 @@ public:
 protected:
     virtual int GetAppcastDownloadFlags() const;
     virtual bool ShouldSkipUpdate(const Appcast& appcast) const;
+    void Run();
 };
 
 


### PR DESCRIPTION
Our application is a long-running application, it's intended to be run for the life of the system.
We desired to have the update-checking occur more frequently, currently the check for updates only occurs at application startup.
This change supports checking for updates periodically while the application is running.
