### PR TITLE
Allow building against WX3.1.0+

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -1473,7 +1473,9 @@ void UI::Run()
     SignalReady();
 
     // Run the app:
+#if wxCHECK_VERSION(3, 0, 3) && !wxCHECK_VERSION(3, 1, 0)
     wxMSWDisableSettingHighDPIAware();
+#endif
     wxEntry(ms_hInstance);
 }
 


### PR DESCRIPTION
The function wxMSWDisableSettingHighDPIAware() no longer exists in
WxWidgets 3.1.0 and later. Futhermore it only existed from 3.0.3
onwards.

This PR adds some compile time checks to disable the call entirely when
an inappropriate version of wx is detected.

From the 3.0.3 code:
since 3.0.3, but only available in 3.0.x, not 3.1+ which doesn't make
the SetDPIProcessAware() call anymore.