### PR TITLE
Wait in background and trigger update on interval

### DIFF
--- a/src/dll_api.cpp
+++ b/src/dll_api.cpp
@@ -75,21 +75,8 @@ WIN_SPARKLE_API void __cdecl win_sparkle_init()
         {
             if ( checkUpdates )
             {
-                static const time_t ONE_DAY = 60*60*24;
-
-                time_t lastCheck = 0;
-                Settings::ReadConfigValue("LastCheckTime", lastCheck);
-                const time_t currentTime = time(NULL);
-
-                // Only check for updates in reasonable intervals:
-                const int interval = win_sparkle_get_update_check_interval();
-                if ( currentTime - lastCheck >= interval )
-                {
-                    // Run the check in background. Only show UI if updates
-                    // are available.
-                    UpdateChecker *check = new UpdateChecker();
-                    check->Start();
-                }
+                UpdateChecker *check = new UpdateChecker();
+                check->Start();
             }
         }
         else // not yet configured

--- a/src/updatechecker.h
+++ b/src/updatechecker.h
@@ -71,6 +71,7 @@ protected:
 
 protected:
     virtual void Run();
+    virtual void PerformUpdateCheck();
     virtual bool IsJoinable() const { return false; }
 };
 
@@ -87,6 +88,7 @@ public:
 protected:
     virtual int GetAppcastDownloadFlags() const;
     virtual bool ShouldSkipUpdate(const Appcast& appcast) const;
+    void Run();
 };
 
 


### PR DESCRIPTION
I read the pull request #116 and wanted to help out doing the additional changes required in order to make it a part of the library.

We implemented a background process program that does work for the user on both Mac and PC. And  we just configured the application for auto updating on both platforms and were baffled when the update never happened.

Today we implemented this by using QTimer to update the application every hour by calling win_sparkle_check_update_without_ui().

But a better solution would be to have this function as a part of the library.

I copied a diff from the original pull request because the original authors repository wasn't open so I couldn't fork it and then I made the changes you requested. I think all of them are reasonable and I don't really get why code was removed but your original code is a good addition so I just restored it and changed the calls.

Please tell me if you require any other changes or if you want to discuss the issue.