### PR TITLE
Remove Query String From URL Filename

### DIFF
--- a/src/download.cpp
+++ b/src/download.cpp
@@ -128,7 +128,7 @@ std::wstring GetURLFileName(const char *url)
 {
     const char *lastSlash = strrchr(url, '/');
     const std::string fn(lastSlash ? lastSlash + 1 : url);
-    return AnsiToWide(fn);
+    return AnsiToWide(fn.find_first_of('?') != std::string::npos ? fn.substr(0, fn.find_first_of('?')) : fn);
 }
 
 struct DownloadCallbackContext

--- a/src/download.cpp
+++ b/src/download.cpp
@@ -127,8 +127,10 @@ bool GetHttpHeader(HINTERNET handle, DWORD whatToGet, DWORD& output)
 std::wstring GetURLFileName(const char *url)
 {
     const char *lastSlash = strrchr(url, '/');
-    const std::string fn(lastSlash ? lastSlash + 1 : url);
-    return AnsiToWide(fn.find_first_of('?') != std::string::npos ? fn.substr(0, fn.find_first_of('?')) : fn);
+    std::string fn(lastSlash ? lastSlash + 1 : url);
+    if (fn.find_first_of('?') != std::string::npos)
+        fn = fn.substr(0, fn.find_first_of('?'));
+    return AnsiToWide(fn);
 }
 
 struct DownloadCallbackContext


### PR DESCRIPTION
Strips out the query string from the URL filename as a '?' is an invalid
character in Windows filenames. This fixes #131