### PR TITLE
[download] - don't close handle when receiving INTERNET_STATUS_CONNECTION_CLOSED

### DIFF
--- a/src/download.cpp
+++ b/src/download.cpp
@@ -158,10 +158,6 @@ void CALLBACK DownloadInternetStatusCallback(_In_ HINTERNET hInternet,
         case INTERNET_STATUS_REQUEST_COMPLETE:
             context->eventRequestComplete.Signal();
             break;
-
-        case INTERNET_STATUS_CONNECTION_CLOSED:
-            context->conn->Close();
-            break;
     }
 }
 


### PR DESCRIPTION
This PR fixes 302 redirects for our mirror system (http://mirrors.kodi.tv).

We are using the following appcast.xml (which you can use easily in your "example_psdk" for reproduction aswell): https://raw.githubusercontent.com/xbmc/SparkleBackend/fix_redirects_demo/sparkleupdate.xml

This announces this file for download:

http://mirrors.kodi.tv/test-builds/win32/KodiSetup-20170611-bb3345af02-sparkle-x86.exe

The mirrors are using mirrorbits and are redirecting to the actual mirror with a 302 found status. (URL redirection).

The dwInternetStatus in the callback when trying to download that file is as follows:

INTERNET_STATUS_HANDLE_CREATED
INTERNET_STATUS_DETECTING_PROXY
INTERNET_STATUS_RESOLVING_NAME
INTERNET_STATUS_NAME_RESOLVED
INTERNET_STATUS_CONNECTING_TO_SERVER
INTERNET_STATUS_CONNECTED_TO_SERVER
INTERNET_STATUS_SENDING_REQUEST
INTERNET_STATUS_REQUEST_SENT
INTERNET_STATUS_RECEIVING_RESPONSE
INTERNET_STATUS_RESPONSE_RECEIVED
INTERNET_STATUS_CLOSING_CONNECTION
INTERNET_STATUS_CONNECTION_CLOSED <- this one is the Problem because in the original callback handler it closes the client side handle
INTERNET_STATUS_REDIRECT
INTERNET_STATUS_DETECTING_PROXY
INTERNET_STATUS_RESOLVING_NAME
INTERNET_STATUS_NAME_RESOLVED
INTERNET_STATUS_CONNECTING_TO_SERVER
INTERNET_STATUS_CONNECTED_TO_SERVER
INTERNET_STATUS_SENDING_REQUEST
INTERNET_STATUS_REQUEST_SENT
INTERNET_STATUS_RECEIVING_RESPONSE
INTERNET_STATUS_RESPONSE_RECEIVED
INTERNET_STATUS_REQUEST_COMPLETE

This means we are operating on an invalid/closed handle after the request was completed and we try to download the file.

Closing the handle in the callback is not needed at all. Because of the destructor of the struct InetHandle
will close the handle as soon as the InetHandle conn goes out of scope from the DownloadFile method.

This change allows us to use winsparkle for our project with the big mirror system as backend.

Thx for considering a merge.

Regards Memphiz of Team Kodi.