### PR TITLE
Fix for update check not triggered

### DIFF
--- a/src/updatechecker.cpp
+++ b/src/updatechecker.cpp
@@ -235,7 +235,7 @@ void UpdateChecker::Run()
         if (checkUpdates)
         {
             const time_t currentTime = time(NULL);
-            time_t lastCheck = currentTime;
+            time_t lastCheck = 0;
             Settings::ReadConfigValue("LastCheckTime", lastCheck);
 
             // Only check for updates in reasonable intervals:


### PR DESCRIPTION
If the LastCheckTime registry value was not set, it would default to
current time, meaning that a check wouldn't happen until after the
interval passed. If the user always closes the app before reaching
the interval, then a check would never happen.

This simply reverts back to previous behavior. Give LastCheckTime a
default value of 0 so that a check happens immediately if there's
been no previous check.

Fixes #144