### PR TITLE
Ensure that biggest window is on a valid display

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -183,7 +183,7 @@ BOOL CALLBACK EnumProcessWindowsCallback(HWND handle, LPARAM lParam)
     RECT rwin;
     GetWindowRect(handle, &rwin);
     wxRect r(rwin.left, rwin.top, rwin.right - rwin.left, rwin.bottom - rwin.top);
-    if (r.width * r.height > data.biggest.width * data.biggest.height)
+    if (wxDisplay::GetFromPoint(wxPoint(r.x, r.y)) != wxNOT_FOUND && r.width * r.height > data.biggest.width * data.biggest.height)
         data.biggest = r;
 
     return TRUE;


### PR DESCRIPTION
Referencing issue #151:

When the application window is minimized, the resultant "biggest" window ends up being positioned off of the view-able display(somewhere around `x` of -32000 and `y` of -32000). Our solution is to make sure that the biggest window within a valid display boundary before setting `data.biggest`. If the check fails, then `data.biggest` becomes empty and the updater UI is subsequently positioned in the center of the main display.