### PR TITLE
Free web browser after display

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -878,6 +878,8 @@ void UpdateDialog::StateUpdateAvailable(const Appcast& info, bool installAutomat
     // take some time to load the MSIE control:
     if ( showRelnotes )
         ShowReleaseNotes(info);
+
+	m_webBrowser->Free();
 }
 
 

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -879,7 +879,7 @@ void UpdateDialog::StateUpdateAvailable(const Appcast& info, bool installAutomat
     if ( showRelnotes )
         ShowReleaseNotes(info);
 
-	m_webBrowser->Free();
+	m_webBrowser.Free();
 }
 
 


### PR DESCRIPTION
Free the web browser object after showing the update window. This allows the initialization code for the web browser to run again if a subsequent check for updates process is executed.

**Added Note:** This issue does appear to _only_ affect release notes that are loaded using the `description` tag. Loading release notes using a url does not appear to have this issue.