### PR TITLE
use https for wxwidgets gitmodule instead of git

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "3rdparty/wxWidgets"]
 	path = 3rdparty/wxWidgets
-	url = git://github.com/wxWidgets/wxWidgets.git
+	url = https://github.com/wxWidgets/wxWidgets.git
 [submodule "3rdparty/expat"]
 	path = 3rdparty/expat
 	url = https://github.com/libexpat/libexpat.git


### PR DESCRIPTION
Some of our machine don't use ssh setup to clone git. I think it's better to use https:// for wxWidgets submodule.

Thanks,


Junian