### PR TITLE
Allow manipulation of WinSparkle settings with user provided functions

### DIFF
--- a/include/winsparkle.h
+++ b/include/winsparkle.h
@@ -248,7 +248,7 @@ typedef struct win_sparkle_config_methods_tag {
     int(__cdecl *config_read)(const char *name, wchar_t *buf, size_t len, void *user_data);
     /// Write @a value as config value @a name 's new value
     void(__cdecl *config_write)(const char *name, const wchar_t *value, void *user_data);
-    /// Delete config value named @ name
+    /// Delete config value named @a name
     void(__cdecl *config_delete)(const char *name, void *user_data);
     /// Arbitrary data which will be passed to the above functions, WinSparkle will not read or alter it.
     void *user_data;

--- a/include/winsparkle.h
+++ b/include/winsparkle.h
@@ -243,7 +243,7 @@ WIN_SPARKLE_API void __cdecl win_sparkle_set_app_build_version(const wchar_t *bu
 WIN_SPARKLE_API void __cdecl win_sparkle_set_registry_path(const char *path);
 
 /// Type used to override WinSparkle's config read function
-typedef int(__cdecl *win_sparkle_config_read_t)(void *custom_data, const char *name, wchar_t *buf, size_t bytes);
+typedef int(__cdecl *win_sparkle_config_read_t)(void *custom_data, const char *name, wchar_t *buf, size_t len);
 /// Type used to override WinSparkle's config write function
 typedef int(__cdecl *win_sparkle_config_write_t)(void *custom_data, const char *name, const wchar_t *value);
 /// Type used to override WinSparkle's config delete function
@@ -265,8 +265,8 @@ typedef int(__cdecl *win_sparkle_config_delete_t)(void *custom_data, const char 
     @param custom_data  arbitrary data which will be passed to your config manipulating 
                         functions, WinSparkle will not read or alter it.
 
-    @note The forth parameter *bytes* of function config_read is the size of *buf* in *bytes*, 
-          not array length!
+    @note There's no guarantee about the thread from which these functions are called,
+          Make sure your functions are thread-safe.
 
 */
 WIN_SPARKLE_API void __cdecl win_sparkle_set_config_methods(void *custom_data, 

--- a/include/winsparkle.h
+++ b/include/winsparkle.h
@@ -242,12 +242,18 @@ WIN_SPARKLE_API void __cdecl win_sparkle_set_app_build_version(const wchar_t *bu
  */
 WIN_SPARKLE_API void __cdecl win_sparkle_set_registry_path(const char *path);
 
-/// Type used to override WinSparkle's config read function
-typedef int(__cdecl *win_sparkle_config_read_t)(void *custom_data, const char *name, wchar_t *buf, size_t len);
-/// Type used to override WinSparkle's config write function
-typedef int(__cdecl *win_sparkle_config_write_t)(void *custom_data, const char *name, const wchar_t *value);
-/// Type used to override WinSparkle's config delete function
-typedef int(__cdecl *win_sparkle_config_delete_t)(void *custom_data, const char *name);
+/// Type used to override WinSparkle configuration's read, write and delete functions
+typedef struct win_sparkle_config_methods_tag {
+    /// Copy config value named @a name to the buffer pointed by @a buf, returns TRUE on success, FALSE on failure
+    int(__cdecl *config_read)(const char *name, wchar_t *buf, size_t len, void *user_data);
+    /// Write @a value as config value @a name 's new value
+    void(__cdecl *config_write)(const char *name, const wchar_t *value, void *user_data);
+    /// Delete config value named @ name
+    void(__cdecl *config_delete)(const char *name, void *user_data);
+    /// Arbitrary data which will be passed to the above functions, WinSparkle will not read or alter it.
+    void *user_data;
+} win_sparkle_config_methods_t;
+
 
 /**
     Override WinSparkle's configuration read, write and delete functions.
@@ -262,18 +268,15 @@ typedef int(__cdecl *win_sparkle_config_delete_t)(void *custom_data, const char 
     If you passed NULL as a configuration action (read, write or delete)'s function pointer, 
     WinSparkle will use the default function for that action.
 
-    @param custom_data  arbitrary data which will be passed to your config manipulating 
-                        functions, WinSparkle will not read or alter it.
+    @param config_methods  Your own configuration read, write and delete functions.
+                           Pass NULL to let WinSparkle continue to use its default functions.
 
     @note There's no guarantee about the thread from which these functions are called,
           Make sure your functions are thread-safe.
 
     @since 0.7
 */
-WIN_SPARKLE_API void __cdecl win_sparkle_set_config_methods(void *custom_data, 
-                                                            win_sparkle_config_read_t   config_read,
-                                                            win_sparkle_config_write_t  config_write,
-                                                            win_sparkle_config_delete_t config_delete);
+WIN_SPARKLE_API void __cdecl win_sparkle_set_config_methods(win_sparkle_config_methods_t *config_methods);
 
 /**
     Sets whether updates are checked automatically or only through a manual call.

--- a/include/winsparkle.h
+++ b/include/winsparkle.h
@@ -254,7 +254,7 @@ typedef int(__cdecl *win_sparkle_config_delete_t)(void *custom_data, const char 
 
     By default, WinSparkle will read, write and delete configuration values by
     interacting directly with Windows Registry.
-    If you want to manage configuration by yourself or you don't want let WinSparkle 
+    If you want to manage configuration by yourself, or if you don't want let WinSparkle 
     write settings directly to the Windows Registry, you can provide your own functions 
     to read, write and delete configuration.
 
@@ -268,6 +268,7 @@ typedef int(__cdecl *win_sparkle_config_delete_t)(void *custom_data, const char 
     @note There's no guarantee about the thread from which these functions are called,
           Make sure your functions are thread-safe.
 
+    @since 0.7
 */
 WIN_SPARKLE_API void __cdecl win_sparkle_set_config_methods(void *custom_data, 
                                                             win_sparkle_config_read_t   config_read,

--- a/include/winsparkle.h
+++ b/include/winsparkle.h
@@ -242,6 +242,38 @@ WIN_SPARKLE_API void __cdecl win_sparkle_set_app_build_version(const wchar_t *bu
  */
 WIN_SPARKLE_API void __cdecl win_sparkle_set_registry_path(const char *path);
 
+/// Type used to override WinSparkle's config read function
+typedef int(__cdecl *win_sparkle_config_read_t)(void *custom_data, const char *name, wchar_t *buf, size_t bytes);
+/// Type used to override WinSparkle's config write function
+typedef int(__cdecl *win_sparkle_config_write_t)(void *custom_data, const char *name, const wchar_t *value);
+/// Type used to override WinSparkle's config delete function
+typedef int(__cdecl *win_sparkle_config_delete_t)(void *custom_data, const char *name);
+
+/**
+    Override WinSparkle's configuration read, write and delete functions.
+
+    By default, WinSparkle will read, write and delete configuration values by
+    interacting directly with Windows Registry.
+    If you want to manage configuration by yourself or you don't want let WinSparkle 
+    write settings directly to the Windows Registry, you can provide your own functions 
+    to read, write and delete configuration.
+
+    These functions needs to return TRUE on success, FALSE on failure.
+    If you passed NULL as a configuration action (read, write or delete)'s function pointer, 
+    WinSparkle will use the default function for that action.
+
+    @param custom_data  arbitrary data which will be passed to your config manipulating 
+                        functions, WinSparkle will not read or alter it.
+
+    @note The forth parameter *bytes* of function config_read is the size of *buf* in *bytes*, 
+          not array length!
+
+*/
+WIN_SPARKLE_API void __cdecl win_sparkle_set_config_methods(void *custom_data, 
+                                                            win_sparkle_config_read_t   config_read,
+                                                            win_sparkle_config_write_t  config_write,
+                                                            win_sparkle_config_delete_t config_delete);
+
 /**
     Sets whether updates are checked automatically or only through a manual call.
 

--- a/src/dll_api.cpp
+++ b/src/dll_api.cpp
@@ -192,14 +192,11 @@ WIN_SPARKLE_API void __cdecl win_sparkle_set_registry_path(const char *path)
     CATCH_ALL_EXCEPTIONS
 }
 
-WIN_SPARKLE_API void __cdecl win_sparkle_set_config_methods(void *custom_data,
-                                                            win_sparkle_config_read_t   config_read,
-                                                            win_sparkle_config_write_t  config_write,
-                                                            win_sparkle_config_delete_t config_delete)
+WIN_SPARKLE_API void __cdecl win_sparkle_set_config_methods(win_sparkle_config_methods_t *config_methods)
 {
     try
     {
-        Settings::SetConfigMethods(custom_data, config_read, config_write, config_delete);
+        Settings::SetConfigMethods(config_methods);
     }
     CATCH_ALL_EXCEPTIONS
 }

--- a/src/dll_api.cpp
+++ b/src/dll_api.cpp
@@ -192,6 +192,18 @@ WIN_SPARKLE_API void __cdecl win_sparkle_set_registry_path(const char *path)
     CATCH_ALL_EXCEPTIONS
 }
 
+WIN_SPARKLE_API void __cdecl win_sparkle_set_config_methods(void *custom_data,
+                                                            win_sparkle_config_read_t   config_read,
+                                                            win_sparkle_config_write_t  config_write,
+                                                            win_sparkle_config_delete_t config_delete)
+{
+    try
+    {
+        Settings::SetConfigMethods(custom_data, config_read, config_write, config_delete);
+    }
+    CATCH_ALL_EXCEPTIONS
+}
+
 WIN_SPARKLE_API void __cdecl win_sparkle_set_automatic_check_for_updates(int state)
 {
     try

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -355,9 +355,6 @@ std::wstring Settings::DoReadConfigValue(const char *name)
 {
     CriticalSectionLocker lock(g_csConfigValues);
 
-    //CriticalSectionLocker for custom config functions
-    CriticalSectionLocker classMemberLock(ms_csVars);
-
     static const int bufferLength = 512;
     wchar_t buf[bufferLength];
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -225,10 +225,26 @@ public:
                                 win_sparkle_config_delete_t customConfigDelete)
     {
         CriticalSectionLocker lock(ms_csVars);
+        
+        ms_currentConfigRead = DefaultConfigRead;
+        ms_currentConfigWrite = DefaultConfigWrite;
+        ms_currentConfigDelete = DefaultConfigDelete;
+
         ms_customConfigData = customConfigData;
-        ms_customConfigRead = customConfigRead;
-        ms_customConfigWrite = customConfigWrite;
-        ms_customConfigDelete = customConfigDelete;
+
+        if (customConfigWrite)
+        {
+            ms_currentConfigRead = customConfigRead;
+        }
+        if (customConfigWrite)
+        {
+            ms_currentConfigWrite = customConfigWrite;
+        }
+        if (customConfigDelete)
+        {
+            ms_currentConfigDelete = customConfigDelete;
+        }
+        
     }
 
     /// Set PEM data and verify in contains valid DSA public key
@@ -325,6 +341,12 @@ private:
     static void DoWriteConfigValue(const char *name, const wchar_t *value);
     static std::wstring DoReadConfigValue(const char *name);
 
+    //Wrapper for RegistryRead
+    static int __cdecl DefaultConfigRead(void *, const char *name, wchar_t *buf, size_t len);
+    //Wrapper for RegistryWrite
+    static int __cdecl DefaultConfigWrite(void *, const char *name, const wchar_t *value);
+    //Wrapper for RegistryDelete
+    static int __cdecl DefaultConfigDelete(void *, const char *name);
 private:
     // guards the variables below:
     static CriticalSection ms_csVars;
@@ -339,9 +361,9 @@ private:
     static std::string  ms_DSAPubKey;
     
     static void *ms_customConfigData;
-    static win_sparkle_config_read_t ms_customConfigRead;
-    static win_sparkle_config_write_t ms_customConfigWrite;
-    static win_sparkle_config_delete_t ms_customConfigDelete;
+    static win_sparkle_config_read_t ms_currentConfigRead;
+    static win_sparkle_config_write_t ms_currentConfigWrite;
+    static win_sparkle_config_delete_t ms_currentConfigDelete;
 };
 
 } // namespace winsparkle

--- a/src/settings.h
+++ b/src/settings.h
@@ -26,6 +26,7 @@
 #ifndef _settings_h_
 #define _settings_h_
 
+#include "winsparkle.h"
 #include "threads.h"
 #include "utils.h"
 
@@ -217,6 +218,19 @@ public:
         ms_registryPath = path;
     }
 
+    /// Set custom configuration read, write and delete functions
+    static void SetConfigMethods(void *customConfigData, 
+                                win_sparkle_config_read_t customConfigRead,
+                                win_sparkle_config_write_t customConfigWrite, 
+                                win_sparkle_config_delete_t customConfigDelete)
+    {
+        CriticalSectionLocker lock(ms_csVars);
+        ms_customConfigData = customConfigData;
+        ms_customConfigRead = customConfigRead;
+        ms_customConfigWrite = customConfigWrite;
+        ms_customConfigDelete = customConfigDelete;
+    }
+
     /// Set PEM data and verify in contains valid DSA public key
     static void SetDSAPubKeyPem(const std::string &pem);
     //@}
@@ -323,6 +337,11 @@ private:
     static std::wstring ms_appVersion;
     static std::wstring ms_appBuildVersion;
     static std::string  ms_DSAPubKey;
+    
+    static void *ms_customConfigData;
+    static win_sparkle_config_read_t ms_customConfigRead;
+    static win_sparkle_config_write_t ms_customConfigWrite;
+    static win_sparkle_config_delete_t ms_customConfigDelete;
 };
 
 } // namespace winsparkle


### PR DESCRIPTION
Added win_sparkle_set_config_methods(), which can be used to override WinSparkle's default Windows Registry interface with custom functions, so users can provide their own functions when they want to manage all configuration by themselves.