### PR TITLE
added allow downgrade functionality

### DIFF
--- a/include/winsparkle.h
+++ b/include/winsparkle.h
@@ -397,6 +397,26 @@ typedef void (__cdecl *win_sparkle_update_cancelled_callback_t)();
 */
 WIN_SPARKLE_API void __cdecl win_sparkle_set_update_cancelled_callback(win_sparkle_update_cancelled_callback_t callback);
 
+/**
+Gets the allow downgrade state
+
+@return  1 if downgrades are allowed, 0 otherwise
+
+@note Defaults to 0 when not yet configured (as happens on first start).
+
+@since 0.6.1
+*/
+WIN_SPARKLE_API int __cdecl win_sparkle_get_allow_downgrades();
+
+/**
+Sets the allow downgrade state.
+
+@param  allowDowngrade 1 to allow downgrades, 0 otherwise
+
+@since 0.6.1
+*/
+WIN_SPARKLE_API void __cdecl win_sparkle_set_allow_downgrades(int allowDowngrade);
+
 //@}
 
 

--- a/src/dll_api.cpp
+++ b/src/dll_api.cpp
@@ -315,6 +315,28 @@ WIN_SPARKLE_API void __cdecl win_sparkle_set_update_cancelled_callback(win_spark
     CATCH_ALL_EXCEPTIONS
 }
 
+WIN_SPARKLE_API void __cdecl win_sparkle_set_allow_downgrades(int allowDowngrades)
+{
+	try
+	{
+		Settings::WriteConfigValue("AllowDowngrades", allowDowngrades != 0);
+	}
+	CATCH_ALL_EXCEPTIONS
+}
+
+WIN_SPARKLE_API int __cdecl win_sparkle_get_allow_downgrades()
+{
+	try
+	{
+		bool allowDowngrades;
+		if (Settings::ReadConfigValue("AllowDowngrades", allowDowngrades, false))
+			return allowDowngrades ? 1 : 0;
+	}
+	CATCH_ALL_EXCEPTIONS
+
+		return 0;
+}
+
 /*--------------------------------------------------------------------------*
                               Manual usage
  *--------------------------------------------------------------------------*/


### PR DESCRIPTION
Some organizations may need the ability to allow application downgrades. This pull request adds a new config value that can be set to allow downgrades. If downgrades are allowed, we only check to make sure the appcast version is different than the current version. If downgrades are not allowed, we check to make sure the appcast version is newer than the current version.