### PR TITLE
remove redundant explicit pointer initializations which are incompatible with older c++ versions

### DIFF
--- a/src/signatureverifier.cpp
+++ b/src/signatureverifier.cpp
@@ -210,8 +210,8 @@ private:
 
     public:
         BIOWrap(const std::string &mem_buf)
+            : bio(BIO_new_mem_buf(mem_buf.c_str(), int(mem_buf.size())))
         {
-            bio = BIO_new_mem_buf(mem_buf.c_str(), int(mem_buf.size()));
             if (!bio)
                 throw std::invalid_argument("Cannot set PEM key mem buffer");
         }
@@ -238,6 +238,7 @@ public:
 
     public:
         DSAPub(const std::string &pem_key)
+            : dsa(NULL)
         {
             BIOWrap bio(pem_key);
             if (!PEM_read_bio_DSA_PUBKEY(bio, &dsa, NULL, NULL))

--- a/src/signatureverifier.cpp
+++ b/src/signatureverifier.cpp
@@ -203,7 +203,7 @@ public:
 private:
     class BIOWrap
     {
-        BIO* bio = NULL;
+        BIO* bio;
 
         BIOWrap(const BIOWrap &);
         BIOWrap &operator=(const BIOWrap &);
@@ -231,7 +231,7 @@ private:
 public:
     class DSAPub
     {
-        DSA *dsa = NULL;
+        DSA *dsa;
 
         DSAPub(const DSAPub &);
         DSAPub &operator=(const DSAPub &);


### PR DESCRIPTION
This is necessary to build in e.g. VS2012. #138 