### PR TITLE
signatureverifier.h: use <stdexcept> to get std::runtime_error

### DIFF
--- a/src/signatureverifier.h
+++ b/src/signatureverifier.h
@@ -26,7 +26,7 @@
 #ifndef _signatureverifier_h_
 #define _signatureverifier_h_
 
-#include <exception>
+#include <stdexcept>
 #include <string>
 
 namespace winsparkle


### PR DESCRIPTION
`std::runtime_error` lives in `<stdexcept>` (see e.g. 22.2.1 of the C++17 standard) and it looks like Visual Studio 2019 version 16.3.2 (or some recent version) changed `<exception>` to not make `std::runtime_error` available via `<exception>`.  This causes a build error.

This behavior is more compliant with the C++ standard (I guess), but it does mean that `signatureverifier.h` needs to be adjusted.