### PR TITLE
Added user callback to intercept and/or bypass default update installer behavior.

### DIFF
--- a/include/winsparkle.h
+++ b/include/winsparkle.h
@@ -505,6 +505,24 @@ typedef void(__cdecl* win_sparkle_update_dismissed_callback_t)();
 */
 WIN_SPARKLE_API void __cdecl win_sparkle_set_update_dismissed_callback(win_sparkle_update_dismissed_callback_t callback);
 
+
+/// Callback type for win_sparkle_user_run_installer_callback()
+typedef int(__cdecl* win_sparkle_user_run_installer_callback_t)(const wchar_t *);
+
+/**
+    Set callback to be called when the update payload is
+    downloaded and read to be executed.or handled in some
+    other manner.
+
+    Return true if the file was handled and to prevent 
+    default WinSparkle handling, which is to execute the
+    payload through the default windows handler (an exe
+    is executed; a zip file is displayed in Explorer.)
+
+    @since 0.8
+*/
+WIN_SPARKLE_API void __cdecl win_sparkle_set_user_run_installer_callback(win_sparkle_user_run_installer_callback_t callback);
+
 //@}
 
 

--- a/src/appcontroller.cpp
+++ b/src/appcontroller.cpp
@@ -40,6 +40,7 @@ win_sparkle_update_cancelled_callback_t    ApplicationController::ms_cbUpdateCan
 win_sparkle_update_skipped_callback_t      ApplicationController::ms_cbUpdateSkipped = NULL;
 win_sparkle_update_postponed_callback_t    ApplicationController::ms_cbUpdatePostponed = NULL;
 win_sparkle_update_dismissed_callback_t    ApplicationController::ms_cbUpdateDismissed = NULL;
+win_sparkle_user_run_installer_callback_t  ApplicationController::ms_cbUserRunInstaller = NULL;
 
 bool ApplicationController::IsReadyToShutdown()
 {
@@ -152,6 +153,18 @@ void ApplicationController::NotifyUpdateDismissed()
             return;
         }
     }
+}
+
+
+bool ApplicationController::UserRunInstallerCallback(const wchar_t* filePath)
+{
+    {
+        if (ms_cbUserRunInstaller)
+        {
+            return ms_cbUserRunInstaller(filePath) != 0;
+        }
+    }
+    return false;
 }
 
 } // namespace winsparkle

--- a/src/appcontroller.h
+++ b/src/appcontroller.h
@@ -78,6 +78,9 @@ public:
     /// Notify that update dialog was dismissed (closed)
     static void NotifyUpdateDismissed();
 
+    /// Run the user installer callback if one is set.
+    static bool UserRunInstallerCallback(const wchar_t*);
+
     //@}
 
     /**
@@ -148,6 +151,12 @@ public:
         ms_cbUpdateDismissed = callback;
     }
 
+    static void SetUserRunInstallerCallback(win_sparkle_user_run_installer_callback_t callback)
+    {
+        CriticalSectionLocker lock(ms_csVars);
+        ms_cbUserRunInstaller = callback;
+    }
+
     //@}
 
 private:
@@ -165,6 +174,8 @@ private:
     static win_sparkle_update_skipped_callback_t      ms_cbUpdateSkipped;
     static win_sparkle_update_postponed_callback_t    ms_cbUpdatePostponed;
     static win_sparkle_update_dismissed_callback_t    ms_cbUpdateDismissed;
+    static win_sparkle_user_run_installer_callback_t  ms_cbUserRunInstaller;
+    
 };
 
 } // namespace winsparkle

--- a/src/dll_api.cpp
+++ b/src/dll_api.cpp
@@ -413,5 +413,10 @@ WIN_SPARKLE_API void __cdecl win_sparkle_check_update_without_ui()
     CATCH_ALL_EXCEPTIONS
 }
 
+WIN_SPARKLE_API void __cdecl win_sparkle_set_user_run_installer_callback(win_sparkle_user_run_installer_callback_t callback)
+{
+    ApplicationController::SetUserRunInstallerCallback(callback);
+}
+
 
 } // extern "C"

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -698,6 +698,12 @@ void UpdateDialog::OnRunInstaller(wxCommandEvent&)
 
 bool UpdateDialog::RunInstaller()
 {
+
+    if (ApplicationController::UserRunInstallerCallback(m_updateFile.t_str()))
+    {
+        return true;
+    }
+
     std::wstring wArgs;
 
     SHELLEXECUTEINFO sei;


### PR DESCRIPTION
Here is a cleaned up pull request. It may not be a perfect use of all of the data structures and concepts you have, but it should be workable if you want to clean it up from here.