### PR TITLE
Add option to auto install after download when using win_sparkle_check_update_with_ui()

### DIFF
--- a/examples/psdk/app_psdk.c
+++ b/examples/psdk/app_psdk.c
@@ -66,7 +66,7 @@ void OnCheckForUpdates(HWND hwnd,
            always shows visible UI. You only need to call it if you have
            a "Check for updates" menu item, otherwise win_sparkle_init()
            checks for updates automatically. */
-        win_sparkle_check_update_with_ui();
+        win_sparkle_check_update_with_ui(0);
     }
 }
 

--- a/include/winsparkle.h
+++ b/include/winsparkle.h
@@ -553,6 +553,9 @@ WIN_SPARKLE_API void __cdecl win_sparkle_set_user_run_installer_callback(win_spa
     the user is told so. If there is an update, the usual "update available"
     window is shown.
 
+    Pass a non-zero value for @a auto_install to skip the "install"
+    confirmation after download and automatically install.
+
     This function returns immediately.
 
     @note Because this function is intended for manual, user-initiated checks

--- a/include/winsparkle.h
+++ b/include/winsparkle.h
@@ -561,7 +561,7 @@ WIN_SPARKLE_API void __cdecl win_sparkle_set_user_run_installer_callback(win_spa
 
     @see win_sparkle_check_update_without_ui()
  */
-WIN_SPARKLE_API void __cdecl win_sparkle_check_update_with_ui();
+WIN_SPARKLE_API void __cdecl win_sparkle_check_update_with_ui(int auto_install);
 
 /**
     Checks if an update is available, showing progress UI to the user and

--- a/src/dll_api.cpp
+++ b/src/dll_api.cpp
@@ -373,7 +373,7 @@ WIN_SPARKLE_API void __cdecl win_sparkle_set_update_dismissed_callback(win_spark
                               Manual usage
  *--------------------------------------------------------------------------*/
 
-WIN_SPARKLE_API void __cdecl win_sparkle_check_update_with_ui()
+WIN_SPARKLE_API void __cdecl win_sparkle_check_update_with_ui(int auto_install)
 {
     try
     {
@@ -381,7 +381,7 @@ WIN_SPARKLE_API void __cdecl win_sparkle_check_update_with_ui()
         UI::ShowCheckingUpdates();
 
         // Then run the actual check in the background.
-        UpdateChecker *check = new ManualUpdateChecker();
+        UpdateChecker *check = new ManualUpdateChecker(auto_install);
         check->Start();
     }
     CATCH_ALL_EXCEPTIONS

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -1367,7 +1367,7 @@ void App::OnNoUpdateFound(wxThreadEvent& event)
     if ( m_win )
     {
         EventPayload payload(event.GetPayload<EventPayload>());
-        m_win->StateNoUpdateFound(payload.installAutomatically);
+        m_win->StateNoUpdateFound(payload.downloadAutomatically);
     }
 }
 
@@ -1537,7 +1537,7 @@ void UI::ShutDown()
 
 
 /*static*/
-void UI::NotifyNoUpdates(bool installAutomatically)
+void UI::NotifyNoUpdates(bool downloadAutomatically)
 {
     ApplicationController::NotifyUpdateNotFound();
 
@@ -1547,7 +1547,7 @@ void UI::NotifyNoUpdates(bool installAutomatically)
         return;
 
     EventPayload payload;
-    payload.installAutomatically = installAutomatically;
+    payload.downloadAutomatically = downloadAutomatically;
     uit.App().SendMsg(MSG_NO_UPDATE_FOUND, &payload);
 }
 

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -1221,7 +1221,7 @@ private:
     void OnNoUpdateFound(wxThreadEvent& event);
     void OnUpdateAvailable(wxThreadEvent& event);
     void OnUpdateError(wxThreadEvent& event);
-    void OnInstallProgress(wxThreadEvent& event);
+    void OnDownloadProgress(wxThreadEvent& event);
     void OnUpdateDownloaded(wxThreadEvent& event);
     void OnAskForPermission(wxThreadEvent& event);
 
@@ -1256,7 +1256,7 @@ App::App()
     Bind(wxEVT_COMMAND_THREAD, &App::OnNoUpdateFound, this, MSG_NO_UPDATE_FOUND);
     Bind(wxEVT_COMMAND_THREAD, &App::OnUpdateAvailable, this, MSG_UPDATE_AVAILABLE);
     Bind(wxEVT_COMMAND_THREAD, &App::OnUpdateError, this, MSG_UPDATE_ERROR);
-    Bind(wxEVT_COMMAND_THREAD, &App::OnInstallProgress, this, MSG_DOWNLOAD_PROGRESS);
+    Bind(wxEVT_COMMAND_THREAD, &App::OnDownloadProgress, this, MSG_DOWNLOAD_PROGRESS);
     Bind(wxEVT_COMMAND_THREAD, &App::OnUpdateDownloaded, this, MSG_UPDATE_DOWNLOADED);
     Bind(wxEVT_COMMAND_THREAD, &App::OnAskForPermission, this, MSG_ASK_FOR_PERMISSION);
 }
@@ -1381,7 +1381,7 @@ void App::OnUpdateError(wxThreadEvent& event)
     }
 }
 
-void App::OnInstallProgress(wxThreadEvent& event)
+void App::OnDownloadProgress(wxThreadEvent& event)
 {
     if ( m_win )
     {

--- a/src/ui.h
+++ b/src/ui.h
@@ -66,7 +66,7 @@ public:
         (i.e. the user is manually checking for updates), "no updates found"
         message is shown. Otherwise, does nothing.
      */
-    static void NotifyNoUpdates(bool installAutomatically);
+    static void NotifyNoUpdates(bool downloadAutomatically);
 
     /**
         Notifies the UI that there was an error retrieving updates.

--- a/src/ui.h
+++ b/src/ui.h
@@ -82,7 +82,7 @@ public:
 
         If the UI thread isn't running yet, it will be launched.
      */
-    static void NotifyUpdateAvailable(const Appcast& info, bool installAutomatically);
+    static void NotifyUpdateAvailable(const Appcast& info, bool downloadAutomatically, bool installAutomatically);
 
     /**
         Notifies the UI about download progress.

--- a/src/updatechecker.cpp
+++ b/src/updatechecker.cpp
@@ -245,18 +245,18 @@ void UpdateChecker::PerformUpdateCheck()
         if ( !appcast.IsValid() || CompareVersions(currentVersion, appcast.Version) >= 0 )
         {
             // The same or newer version is already installed.
-            UI::NotifyNoUpdates(ShouldAutomaticallyInstall());
+            UI::NotifyNoUpdates(ShouldAutomaticallyDownload());
             return;
         }
 
         // Check if the user opted to ignore this particular version.
         if ( ShouldSkipUpdate(appcast) )
         {
-            UI::NotifyNoUpdates(ShouldAutomaticallyInstall());
+            UI::NotifyNoUpdates(ShouldAutomaticallyDownload());
             return;
         }
 
-        UI::NotifyUpdateAvailable(appcast, ShouldAutomaticallyInstall());
+        UI::NotifyUpdateAvailable(appcast, ShouldAutomaticallyDownload(), ShouldAutomaticallyInstall());
     }
     catch ( ... )
     {

--- a/src/updatechecker.h
+++ b/src/updatechecker.h
@@ -102,7 +102,6 @@ public:
 
 protected:
     virtual bool ShouldSkipUpdate(const Appcast& appcast) const;
-
     virtual bool ShouldAutomaticallyInstall() const { return m_autoInstall; }
 
 private:

--- a/src/updatechecker.h
+++ b/src/updatechecker.h
@@ -63,7 +63,9 @@ protected:
     /// Should give version be ignored?
     virtual bool ShouldSkipUpdate(const Appcast& appcast) const;
 
-    /// Should we install the update or prompt the user for options first?
+    /// Should we download the update or prompt the user for options first?
+    virtual bool ShouldAutomaticallyDownload() const { return false; }
+    /// Should we install the update after download or require action from the user first?
     virtual bool ShouldAutomaticallyInstall() const { return false; }
 
 protected:
@@ -95,15 +97,21 @@ class ManualUpdateChecker : public OneShotUpdateChecker
 {
 public:
     /// Creates checker thread.
+    ManualUpdateChecker(bool autoInstall) : OneShotUpdateChecker(), m_autoInstall(autoInstall) {}
     ManualUpdateChecker() : OneShotUpdateChecker() {}
 
 protected:
     virtual bool ShouldSkipUpdate(const Appcast& appcast) const;
+
+    virtual bool ShouldAutomaticallyInstall() const { return m_autoInstall; }
+
+private:
+    bool m_autoInstall{false};
 };
 
 
 /**
-    Update checker used to automatically install updates when found.
+    Update checker used to automatically download and install updates when found.
  */
 class ManualAutoInstallUpdateChecker : public ManualUpdateChecker
 {
@@ -112,7 +120,8 @@ public:
     ManualAutoInstallUpdateChecker() : ManualUpdateChecker() {}
 
 protected:
-    virtual bool ShouldAutomaticallyInstall() const { return true; };
+    virtual bool ShouldAutomaticallyDownload() const { return true; }
+    virtual bool ShouldAutomaticallyInstall() const { return true; }
 };
 
 


### PR DESCRIPTION
When `win_sparkle_check_update_with_ui()` is used to allow the user to manually check for an update (i.e. via a menu item), the flow is the following (assuming an update is available):

1) Click menu item to check for updates
2) WinSparkle dialog shows that a new version is available
3) User clicks _"Install update"_

![image](https://user-images.githubusercontent.com/1648285/116656989-3ef52400-a9c0-11eb-902c-26eaa9881838.png)

4) Update starts downloading
5) After download is complete, the user must then again click _"Install update"_

![image](https://user-images.githubusercontent.com/1648285/116657009-474d5f00-a9c0-11eb-87c8-95df14521181.png)


This PR allows the additional (and maybe redundant?) confirmation at Step (5) to be skipped and the update to be automatically installed after downloading, via an arg: `win_sparkle_check_update_with_ui(1);`

This is achieved in code by using two flags for the auto logic: one each for download and install