### PR TITLE
chore(ui): Catch fatal exceptions when showing release notes

### DIFF
--- a/3rdparty/expat.vcxproj
+++ b/3rdparty/expat.vcxproj
@@ -36,6 +36,7 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='14'">v140_xp</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='15'">v141_xp</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17'">v143</PlatformToolset>
     <XPDeprecationWarning>false</XPDeprecationWarning>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -47,6 +48,7 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='14'">v140</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='15'">v141</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17'">v143</PlatformToolset>
     <XPDeprecationWarning>false</XPDeprecationWarning>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -58,6 +60,7 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='14'">v140_xp</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='15'">v141_xp</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17'">v143</PlatformToolset>
     <XPDeprecationWarning>false</XPDeprecationWarning>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
@@ -70,6 +73,7 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='14'">v140</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='15'">v141</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17'">v143</PlatformToolset>
     <XPDeprecationWarning>false</XPDeprecationWarning>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>

--- a/3rdparty/libcrypto.vcxproj
+++ b/3rdparty/libcrypto.vcxproj
@@ -36,6 +36,7 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='14'">v140_xp</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='15'">v141_xp</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17'">v143</PlatformToolset>
     <XPDeprecationWarning>false</XPDeprecationWarning>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -47,6 +48,7 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='14'">v140</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='15'">v141</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17'">v143</PlatformToolset>
     <XPDeprecationWarning>false</XPDeprecationWarning>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -58,6 +60,7 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='14'">v140_xp</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='15'">v141_xp</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17'">v143</PlatformToolset>
     <XPDeprecationWarning>false</XPDeprecationWarning>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
@@ -70,6 +73,7 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='14'">v140</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='15'">v141</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17'">v143</PlatformToolset>
     <XPDeprecationWarning>false</XPDeprecationWarning>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>

--- a/3rdparty/wx.vcxproj
+++ b/3rdparty/wx.vcxproj
@@ -195,6 +195,7 @@
     <ClCompile Include="wxWidgets\src\common\bmpbase.cpp" />
     <ClCompile Include="wxWidgets\src\common\btncmn.cpp" />
     <ClCompile Include="wxWidgets\src\common\checkboxcmn.cpp" />
+    <ClCompile Include="wxWidgets\src\common\choiccmn.cpp" />
     <ClCompile Include="wxWidgets\src\common\clntdata.cpp" />
     <ClCompile Include="wxWidgets\src\common\cmdline.cpp" />
     <ClCompile Include="wxWidgets\src\common\cmdproc.cpp" />
@@ -297,6 +298,7 @@
     <ClCompile Include="wxWidgets\src\msw\brush.cpp" />
     <ClCompile Include="wxWidgets\src\msw\button.cpp" />
     <ClCompile Include="wxWidgets\src\msw\checkbox.cpp" />
+    <ClCompile Include="wxWidgets\src\msw\choice.cpp" />
     <ClCompile Include="wxWidgets\src\msw\colour.cpp" />
     <ClCompile Include="wxWidgets\src\msw\control.cpp" />
     <ClCompile Include="wxWidgets\src\msw\cursor.cpp" />

--- a/3rdparty/wx.vcxproj
+++ b/3rdparty/wx.vcxproj
@@ -37,6 +37,7 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='14'">v140_xp</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='15'">v141_xp</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17'">v143</PlatformToolset>
     <XPDeprecationWarning>false</XPDeprecationWarning>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -48,6 +49,7 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='14'">v140</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='15'">v141</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17'">v143</PlatformToolset>
     <XPDeprecationWarning>false</XPDeprecationWarning>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -59,6 +61,7 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='14'">v140_xp</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='15'">v141_xp</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17'">v143</PlatformToolset>
     <XPDeprecationWarning>false</XPDeprecationWarning>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
@@ -71,6 +74,7 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='14'">v140</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='15'">v141</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17'">v143</PlatformToolset>
     <XPDeprecationWarning>false</XPDeprecationWarning>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>

--- a/3rdparty/wx.vcxproj.filters
+++ b/3rdparty/wx.vcxproj.filters
@@ -511,5 +511,11 @@
     <ClCompile Include="wxWidgets\src\msw\window.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="wxWidgets\src\common\choiccmn.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="wxWidgets\src\msw\choice.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/3rdparty/wxWidgets_setup_h/wx/setup.h
+++ b/3rdparty/wxWidgets_setup_h/wx/setup.h
@@ -881,7 +881,7 @@
 #define wxUSE_CALENDARCTRL  0   // wxCalendarCtrl
 #define wxUSE_CHECKBOX      1   // wxCheckBox
 #define wxUSE_CHECKLISTBOX  0   // wxCheckListBox (requires wxUSE_OWNER_DRAWN)
-#define wxUSE_CHOICE        0   // wxChoice
+#define wxUSE_CHOICE        1   // wxChoice
 #define wxUSE_COLLPANE      0   // wxCollapsiblePane
 #define wxUSE_COLOURPICKERCTRL 0    // wxColourPickerCtrl
 #define wxUSE_COMBOBOX      0   // wxComboBox

--- a/WinSparkle.vcxproj
+++ b/WinSparkle.vcxproj
@@ -38,6 +38,7 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='15'">v141_xp</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16'">v142</PlatformToolset>
     <XPDeprecationWarning>false</XPDeprecationWarning>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17'">v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
@@ -49,6 +50,7 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='15'">v141</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16'">v142</PlatformToolset>
     <XPDeprecationWarning>false</XPDeprecationWarning>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17'">v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
@@ -61,6 +63,7 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16'">v142</PlatformToolset>
     <XPDeprecationWarning>false</XPDeprecationWarning>
     <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17'">v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
@@ -73,6 +76,7 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16'">v142</PlatformToolset>
     <XPDeprecationWarning>false</XPDeprecationWarning>
     <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17'">v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings" />

--- a/examples/example_psdk.vcxproj
+++ b/examples/example_psdk.vcxproj
@@ -36,6 +36,7 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='14'">v140</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='15'">v141</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17'">v143</PlatformToolset>
     <XPDeprecationWarning>false</XPDeprecationWarning>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -47,6 +48,7 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='14'">v140</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='15'">v141</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17'">v143</PlatformToolset>
     <XPDeprecationWarning>false</XPDeprecationWarning>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -58,6 +60,7 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='14'">v140</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='15'">v141</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17'">v143</PlatformToolset>
     <XPDeprecationWarning>false</XPDeprecationWarning>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
@@ -70,6 +73,7 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='14'">v140</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='15'">v141</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)'=='16'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='17'">v143</PlatformToolset>
     <XPDeprecationWarning>false</XPDeprecationWarning>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>

--- a/include/winsparkle-version.h
+++ b/include/winsparkle-version.h
@@ -32,7 +32,7 @@
 
 #define WIN_SPARKLE_VERSION_MAJOR   0
 #define WIN_SPARKLE_VERSION_MINOR   7
-#define WIN_SPARKLE_VERSION_MICRO   0
+#define WIN_SPARKLE_VERSION_MICRO   1
 
 /**
     Checks if WinSparkle version is at least @a major.@a minor.@a micro.

--- a/include/winsparkle-version.h
+++ b/include/winsparkle-version.h
@@ -32,7 +32,7 @@
 
 #define WIN_SPARKLE_VERSION_MAJOR   0
 #define WIN_SPARKLE_VERSION_MINOR   7
-#define WIN_SPARKLE_VERSION_MICRO   1
+#define WIN_SPARKLE_VERSION_MICRO   2
 
 /**
     Checks if WinSparkle version is at least @a major.@a minor.@a micro.

--- a/include/winsparkle-version.h
+++ b/include/winsparkle-version.h
@@ -32,7 +32,7 @@
 
 #define WIN_SPARKLE_VERSION_MAJOR   0
 #define WIN_SPARKLE_VERSION_MINOR   7
-#define WIN_SPARKLE_VERSION_MICRO   2
+#define WIN_SPARKLE_VERSION_MICRO   3
 
 /**
     Checks if WinSparkle version is at least @a major.@a minor.@a micro.

--- a/include/winsparkle.h
+++ b/include/winsparkle.h
@@ -353,6 +353,15 @@ WIN_SPARKLE_API int __cdecl win_sparkle_get_update_check_interval();
 */
 WIN_SPARKLE_API time_t __cdecl win_sparkle_get_last_check_time();
 
+/**
+Sets the time for the last update check.
+
+    @param time Set the time for the last update check.
+
+    @since 2.4 - CE-specific version
+*/
+WIN_SPARKLE_API void __cdecl win_sparkle_set_last_check_time(time_t time);
+
 /// Callback type for win_sparkle_error_callback()
 typedef void (__cdecl *win_sparkle_error_callback_t)();
 
@@ -528,6 +537,35 @@ typedef int(__cdecl* win_sparkle_user_run_installer_callback_t)(const wchar_t *)
     @since 0.8
 */
 WIN_SPARKLE_API void __cdecl win_sparkle_set_user_run_installer_callback(win_sparkle_user_run_installer_callback_t callback);
+
+
+/// Callback type for win_sparkle_alternate_appcast_callback()
+typedef int(__cdecl* win_sparkle_alternate_appcast_callback_t)(
+    bool manual, int bufferSize, char* version, char* downloadUrl, char* releaseNotesUrl, char* webBrowserUrl, char* title, char* description);
+
+/**
+    Set callback to be called when Appcast data is needed to be
+    acquired from an alternate source (i.e. provided from
+    outside of Winsparkle)
+
+    Parameters:
+        - manual : What triggered the update processing? Manual (direct user initiated) OR automatic (timed/scheduled)
+        - buffersize : Maximum size of buffers that the callback function can populate
+        - version : the available (new) version o the application
+        - downloadUrl : the location where the updater can be downloaded from
+        - releaseNotesUrl : the location where the associated release notes can be found at
+        - webBrowserUrl : the location to launch in web browser for manual download
+        - title : the title of the update
+        - description :the description of the update
+
+    The callback returns:
+    - 1 : when Appcast data was successfully acquired, indicating update is available
+    - 0 : when Appcast data was successfully acquired, indicating that NO update is available
+    - WINSPARKLE_RETURN_ERROR : when Appcast data was NOT successfully acquired, in which case WinSparkle default handling should proceed
+
+    @since 0.7.1
+*/
+WIN_SPARKLE_API void __cdecl win_sparkle_set_alternate_appcast_callback(win_sparkle_alternate_appcast_callback_t callback);
 
 //@}
 

--- a/include/winsparkle.h
+++ b/include/winsparkle.h
@@ -28,6 +28,10 @@
 
 #include <stddef.h>
 
+#ifndef __cplusplus
+#include <stdbool.h>
+#endif
+
 #include "winsparkle-version.h"
 
 #if !defined(BUILDING_WIN_SPARKLE) && defined(_MSC_VER)

--- a/src/appcontroller.cpp
+++ b/src/appcontroller.cpp
@@ -24,6 +24,7 @@
  */
 
 #include "appcontroller.h"
+#include "appcast.h"
 
 
 namespace winsparkle
@@ -41,6 +42,7 @@ win_sparkle_update_skipped_callback_t      ApplicationController::ms_cbUpdateSki
 win_sparkle_update_postponed_callback_t    ApplicationController::ms_cbUpdatePostponed = NULL;
 win_sparkle_update_dismissed_callback_t    ApplicationController::ms_cbUpdateDismissed = NULL;
 win_sparkle_user_run_installer_callback_t  ApplicationController::ms_cbUserRunInstaller = NULL;
+win_sparkle_alternate_appcast_callback_t   ApplicationController::ms_cbAlternateAppcast = NULL;
 
 bool ApplicationController::IsReadyToShutdown()
 {
@@ -162,6 +164,53 @@ int ApplicationController::UserRunInstallerCallback(const wchar_t* filePath)
         return false;
 
     return ms_cbUserRunInstaller(filePath);
+}
+
+int ApplicationController::AlternateAppcastCallback(bool manual, struct Appcast& appcast)
+{
+    // Get the alternate appcast data (use the user defined callback) if one is defined
+    if (!ms_cbAlternateAppcast)
+        return 0;
+
+    // Use temporary storage for receiving the data (to be populated by the callback)
+    // The DLL <-> App interface does not allow for (easy) passing (marshalling) of
+    // dynamic objects like std::string, so the implementation is limited to passing
+    // pointers to predefined size char arrays that need to be defined large enough
+    // to store representations of version strings, URLs and some arbitrary strings.
+    // The size of the arrays is also passed along to the App as a parameter to be able
+    // to prevent buffer overruns. This of course assumes that the size parameter is
+    // checked for and considered in the callback.
+    static const int appcastBufferLength = 500;
+
+    char version[appcastBufferLength];
+    char downloadUrl[appcastBufferLength];
+    char releaseNotesUrl[appcastBufferLength];
+    char webBrowserUrl[appcastBufferLength];
+    char title[appcastBufferLength];
+    char description[appcastBufferLength];
+
+    memset(version, 0x00, appcastBufferLength);
+    memset(downloadUrl, 0x00, appcastBufferLength);
+    memset(releaseNotesUrl, 0x00, appcastBufferLength);
+    memset(webBrowserUrl, 0x00, appcastBufferLength);
+    memset(title, 0x00, appcastBufferLength);
+    memset(description, 0x00, appcastBufferLength);
+
+    // Actually get the alternate appcast data (execute the user defined callback)
+    int retVal = ms_cbAlternateAppcast(manual, appcastBufferLength - 1, version, downloadUrl, releaseNotesUrl, webBrowserUrl, title, description);
+
+    if (retVal == 1)
+    {
+        // Update is available, marshall the data to our space
+        appcast.Version = version;
+        appcast.DownloadURL = downloadUrl;
+        appcast.ReleaseNotesURL = releaseNotesUrl;
+        appcast.WebBrowserURL = webBrowserUrl;
+        appcast.Title = title;
+        appcast.Description = description;
+    }
+
+    return retVal;
 }
 
 } // namespace winsparkle

--- a/src/appcontroller.h
+++ b/src/appcontroller.h
@@ -81,6 +81,10 @@ public:
     /// Run the user installer callback if one is set.
     static int UserRunInstallerCallback(const wchar_t*);
 
+    /// Run the alternate appcast callback if one is set.
+    /// See return status for win_sparkle_alternate_appcast_callback_t
+    static int AlternateAppcastCallback(bool manual, struct Appcast& appcast);
+
     //@}
 
     /**
@@ -157,6 +161,12 @@ public:
         ms_cbUserRunInstaller = callback;
     }
 
+    static void SetAlternateAppcastCallback(win_sparkle_alternate_appcast_callback_t callback)
+    {
+        CriticalSectionLocker lock(ms_csVars);
+        ms_cbAlternateAppcast = callback;
+    }
+
     //@}
 
 private:
@@ -175,7 +185,7 @@ private:
     static win_sparkle_update_postponed_callback_t    ms_cbUpdatePostponed;
     static win_sparkle_update_dismissed_callback_t    ms_cbUpdateDismissed;
     static win_sparkle_user_run_installer_callback_t  ms_cbUserRunInstaller;
-    
+    static win_sparkle_alternate_appcast_callback_t   ms_cbAlternateAppcast;
 };
 
 } // namespace winsparkle

--- a/src/dll_api.cpp
+++ b/src/dll_api.cpp
@@ -243,14 +243,13 @@ WIN_SPARKLE_API int __cdecl win_sparkle_get_automatic_check_for_updates()
 
 WIN_SPARKLE_API void __cdecl win_sparkle_set_update_check_interval(int interval)
 {
-    static const int MIN_CHECK_INTERVAL = 3600; // one hour
-
     try
     {
-        if ( interval < MIN_CHECK_INTERVAL )
+        // Allow for easy testing
+        if ( interval < Settings:: MIN_CHECK_INTERVAL )
         {
-            winsparkle::LogError("Invalid update interval (min: 3600 seconds)");
-            interval = MIN_CHECK_INTERVAL;
+            winsparkle::LogError("Invalid update interval (min: 300 seconds)");
+            interval = Settings::MIN_CHECK_INTERVAL;
         }
 
         Settings::WriteConfigValue("UpdateInterval", interval);
@@ -286,6 +285,15 @@ WIN_SPARKLE_API time_t __cdecl win_sparkle_get_last_check_time()
     CATCH_ALL_EXCEPTIONS
 
     return DEFAULT_LAST_CHECK_TIME;
+}
+
+WIN_SPARKLE_API void __cdecl win_sparkle_set_last_check_time(time_t lastCheckTime)
+{
+    try
+    {
+        Settings::WriteConfigValue("LastCheckTime", lastCheckTime);
+    }
+    CATCH_ALL_EXCEPTIONS
 }
 
 WIN_SPARKLE_API void __cdecl win_sparkle_set_error_callback(win_sparkle_error_callback_t callback)
@@ -418,5 +426,9 @@ WIN_SPARKLE_API void __cdecl win_sparkle_set_user_run_installer_callback(win_spa
     ApplicationController::SetUserRunInstallerCallback(callback);
 }
 
+WIN_SPARKLE_API void __cdecl win_sparkle_set_alternate_appcast_callback(win_sparkle_alternate_appcast_callback_t callback)
+{
+    ApplicationController::SetAlternateAppcastCallback(callback);
+}
 
 } // extern "C"

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -171,9 +171,6 @@ std::string Settings::GetCustomResource(const char *name, const char *type)
 std::string Settings::GetDefaultRegistryPath()
 {
     std::string s("Software\\");
-    std::wstring vendor = Settings::GetCompanyName();
-    if ( !vendor.empty() )
-        s += WideToAnsi(vendor) + "\\";
     s += WideToAnsi(Settings::GetAppName());
     s += "\\WinSparkle";
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -334,6 +334,8 @@ public:
     // Deletes value from registry.
     static void DeleteConfigValue(const char *name);
 
+    static const int MIN_CHECK_INTERVAL = 300; // 5 minutes
+
     //@}
 
 private:

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -45,6 +45,7 @@
 #include <wx/intl.h>
 #include <wx/sizer.h>
 #include <wx/button.h>
+#include <wx/choice.h>
 #include <wx/filename.h>
 #include <wx/gauge.h>
 #include <wx/statbmp.h>
@@ -68,6 +69,11 @@
 #ifndef ERROR_RESOURCE_ENUM_USER_STOP
 #define ERROR_RESOURCE_ENUM_USER_STOP                      15106
 #endif
+
+const int DOWNLOAD_NOW = 0;
+const int REMIND_ONE_HOUR = 1;
+const int REMIND_ONE_DAY = 2;
+const int REMIND_ONE_WEEK = 3;
 
 namespace winsparkle
 {
@@ -329,8 +335,6 @@ WinSparkleDialog::WinSparkleDialog()
     wxSize dpi = wxClientDC(this).GetPPI();
     m_scaleFactor = dpi.y / 96.0;
 
-    SetIcon(LoadNamedIcon(UI::GetDllHINSTANCE(), L"UpdateAvailable", GetSystemMetrics(SM_CXSMICON)));
-
     wxSizer *topSizer = new wxBoxSizer(wxHORIZONTAL);
 
     // Load the dialog box icon: the first 48x48 application icon will be loaded, if available,
@@ -392,7 +396,6 @@ void WinSparkleDialog::SetHeadingFont(wxWindow *win)
         // 9pt is base font, 12pt is for "Main instructions". See
         // http://msdn.microsoft.com/en-us/library/aa511282%28v=MSDN.10%29.aspx
         f.SetPointSize(f.GetPointSize() + 3);
-        win->SetForegroundColour(wxColour(0x00, 0x33, 0x99));
     }
     else // Windows XP/2000
     {
@@ -408,9 +411,8 @@ void WinSparkleDialog::SetHeadingFont(wxWindow *win)
                       Window for communicating with the user
  *--------------------------------------------------------------------------*/
 
-const int ID_SKIP_VERSION = wxNewId();
-const int ID_REMIND_LATER = wxNewId();
-const int ID_INSTALL = wxNewId();
+const int ID_REMIND_OPTIONS = wxNewId();
+const int ID_DOWNLOAD = wxNewId();
 const int ID_RUN_INSTALLER = wxNewId();
 
 class UpdateDialog : public WinSparkleDialog
@@ -439,9 +441,7 @@ private:
     void OnCloseButton(wxCommandEvent& event);
     void OnClose(wxCloseEvent& event);
 
-    void OnSkipVersion(wxCommandEvent&);
-    void OnRemindLater(wxCommandEvent&);
-    void OnInstall(wxCommandEvent&);
+    void OnDownload(wxCommandEvent&);
 
     void OnRunInstaller(wxCommandEvent&);
 
@@ -465,6 +465,7 @@ private:
     wxSizer      *m_updateButtonsSizer;
     wxSizer      *m_releaseNotesSizer;
     wxPanel      *m_browserParent;
+    wxChoice     *m_remindChoiceList;
 
     wxAutoOleInterface<IWebBrowser2> m_webBrowser;
 
@@ -474,7 +475,7 @@ private:
     wxString m_updateFile;
     // space separated arguments to update file (only valid after StateUpdateDownloaded)
     std::string m_installerArguments;
-    // downloader (only valid between OnInstall and OnUpdateDownloaded)
+    // downloader (only valid between OnDownload and OnUpdateDownloaded)
     UpdateDownloader* m_downloader;
     // whether the update should be installed without prompting the user
     bool m_installAutomatically;
@@ -533,21 +534,16 @@ UpdateDialog::UpdateDialog()
 
     m_buttonSizer = new wxBoxSizer(wxHORIZONTAL);
 
+    const wxString REMIND_OPTIONS[] = { L"Download now", L"Remind me in an hour", L"Remind me tomorrow", L"Remind me in a week" };
+    m_remindChoiceList = new wxChoice(this, ID_REMIND_OPTIONS, wxDefaultPosition, wxDefaultSize, sizeof(REMIND_OPTIONS) / sizeof(REMIND_OPTIONS[0]), REMIND_OPTIONS);
+    m_remindChoiceList->SetSelection(DOWNLOAD_NOW);
+
     m_updateButtonsSizer = new wxBoxSizer(wxHORIZONTAL);
-    m_updateButtonsSizer->Add
-                          (
-                            new wxButton(this, ID_SKIP_VERSION, _("Skip this version")),
-                            wxSizerFlags().Border(wxRIGHT, PX(20))
-                          );
     m_updateButtonsSizer->AddStretchSpacer(1);
+    m_updateButtonsSizer->Add(m_remindChoiceList, wxSizerFlags().Border(wxRIGHT, PX(20)));
     m_updateButtonsSizer->Add
                           (
-                            new wxButton(this, ID_REMIND_LATER, _("Remind me later")),
-                            wxSizerFlags().Border(wxRIGHT, PX(10))
-                          );
-    m_updateButtonsSizer->Add
-                          (
-                            m_installButton = new wxButton(this, ID_INSTALL, _("Install update")),
+                            m_installButton = new wxButton(this, ID_DOWNLOAD, _("OK")),
                             wxSizerFlags()
                           );
     m_buttonSizer->Add(m_updateButtonsSizer, wxSizerFlags(1));
@@ -576,9 +572,7 @@ UpdateDialog::UpdateDialog()
     Bind(wxEVT_CLOSE_WINDOW, &UpdateDialog::OnClose, this);
     Bind(wxEVT_TIMER, &UpdateDialog::OnTimer, this);
     Bind(wxEVT_COMMAND_BUTTON_CLICKED, &UpdateDialog::OnCloseButton, this, wxID_CANCEL);
-    Bind(wxEVT_COMMAND_BUTTON_CLICKED, &UpdateDialog::OnSkipVersion, this, ID_SKIP_VERSION);
-    Bind(wxEVT_COMMAND_BUTTON_CLICKED, &UpdateDialog::OnRemindLater, this, ID_REMIND_LATER);
-    Bind(wxEVT_COMMAND_BUTTON_CLICKED, &UpdateDialog::OnInstall, this, ID_INSTALL);
+    Bind(wxEVT_COMMAND_BUTTON_CLICKED, &UpdateDialog::OnDownload, this, ID_DOWNLOAD);
     Bind(wxEVT_COMMAND_BUTTON_CLICKED, &UpdateDialog::OnRunInstaller, this, ID_RUN_INSTALLER);
 }
 
@@ -629,38 +623,47 @@ void UpdateDialog::OnClose(wxCloseEvent&)
 }
 
 
-void UpdateDialog::OnSkipVersion(wxCommandEvent&)
+void UpdateDialog::OnDownload(wxCommandEvent&)
 {
-    Settings::WriteConfigValue("SkipThisVersion", m_appcast.Version);
-    ApplicationController::NotifyUpdateSkipped();
-    Close();
-}
+    static const int ONE_HOUR_IN_SECONDS = 3600;
+    static const int ONE_DAY_IN_SECONDS = 86400;
+    static const int ONE_WEEK_IN_SECONDS = 604800;
+    int currentSelection = m_remindChoiceList->GetCurrentSelection();
 
-
-void UpdateDialog::OnRemindLater(wxCommandEvent&)
-{
-    // Just abort the update. Next time it's scheduled to run,
-    // the user will be prompted.
-    ApplicationController::NotifyUpdatePostponed();
-    Close();
-}
-
-
-void UpdateDialog::OnInstall(wxCommandEvent&)
-{
-    if ( !m_appcast.HasDownload() )
+    int updateInterval = ONE_DAY_IN_SECONDS;
+    switch (currentSelection)
     {
-        wxLaunchDefaultBrowser(m_appcast.WebBrowserURL, wxBROWSER_NEW_WINDOW);
-        Close();
-    }
-    else if ( m_downloader == NULL )
-    {
-        StateDownloading();
+    case DOWNLOAD_NOW:
+        if (!m_appcast.HasDownload())
+        {
+            wxLaunchDefaultBrowser(m_appcast.WebBrowserURL, wxBROWSER_NEW_WINDOW);
+            Close();
+        }
+        else if (m_downloader == NULL)
+        {
+            StateDownloading();
 
-        // Run the download in background.
-        m_downloader = new UpdateDownloader(m_appcast);
-        m_downloader->Start();
+            // Run the download in background.
+            m_downloader = new UpdateDownloader(m_appcast);
+            m_downloader->Start();
+        }
+        return;
+    case REMIND_ONE_HOUR:
+        updateInterval = ONE_HOUR_IN_SECONDS;
+        break;
+    case REMIND_ONE_DAY:
+        updateInterval = ONE_DAY_IN_SECONDS;
+        break;
+    case REMIND_ONE_WEEK:
+        updateInterval = ONE_WEEK_IN_SECONDS;
+        break;
+    default:
+        updateInterval = ONE_DAY_IN_SECONDS;
+        break;
     }
+
+    Settings::WriteConfigValue("UpdateInterval", updateInterval);
+    Close();
 }
 
 void UpdateDialog::OnRunInstaller(wxCommandEvent&)
@@ -769,27 +772,12 @@ void UpdateDialog::StateNoUpdateFound(bool installAutomatically)
 
     LayoutChangesGuard guard(this);
 
-    m_heading->SetLabel(_("You're up to date!"));
+    m_heading->SetLabel(_("You are up to date!"));
 
-    wxString msg;
-    try
-    {
-        msg = wxString::Format
-              (
-                  _("%s %s is currently the newest version available."),
-                  Settings::GetAppName(),
-                  Settings::GetAppVersion()
-              );
-    }
-    catch ( std::exception& )
-    {
-        // GetAppVersion() may fail
-        msg = "Error: Updates checking not properly configured.";
-    }
-
+    wxString msg = _("There are no new versions available at this time.");
     SetMessage(msg);
 
-    m_closeButton->SetLabel(_("Close"));
+    m_closeButton->SetLabel(_("OK"));
     m_closeButton->SetDefault();
     EnablePulsing(false);
 
@@ -824,7 +812,7 @@ void UpdateDialog::StateUpdateError(ErrorCode err)
     }
     SetMessage(msg);
 
-    m_closeButton->SetLabel(_("Cancel"));
+    m_closeButton->SetLabel(_("OK"));
     m_closeButton->SetDefault();
     EnablePulsing(false);
 
@@ -848,7 +836,7 @@ void UpdateDialog::StateUpdateAvailable(const Appcast& info, bool installAutomat
     if ( installAutomatically )
     {
         wxCommandEvent nullEvent;
-        OnInstall(nullEvent);
+        OnDownload(nullEvent);
         return;
     }
 
@@ -879,8 +867,8 @@ void UpdateDialog::StateUpdateAvailable(const Appcast& info, bool installAutomat
         (
             wxString::Format
             (
-                _("%s %s is now available (you have %s). Would you like to download it now?"),
-                appname, ver_new, ver_my
+                _("You are currently using %s version %s.\nWould you like to download our new version (%s) now?"),
+                appname, ver_my, ver_new
             ),
             showRelnotes ? RELNOTES_WIDTH : MESSAGE_AREA_WIDTH
         );
@@ -1042,10 +1030,14 @@ void UpdateDialog::ShowReleaseNotes(const Appcast& info)
 
     if( !info.ReleaseNotesURL.empty() )
     {
+        VARIANT varFlags;
+        varFlags.vt = VT_I4;
+        varFlags.llVal = (navNoHistory | navNoReadFromCache | navNoWriteToCache);
+
         m_webBrowser->Navigate
                       (
                           wxBasicString(info.ReleaseNotesURL),
-                          NULL,  // Flags
+                          &varFlags,  // Flags
                           NULL,  // TargetFrameName
                           NULL,  // PostData
                           NULL   // Headers

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -889,8 +889,17 @@ void UpdateDialog::StateUpdateAvailable(const Appcast& info, bool installAutomat
 
     // Only show the release notes now that the layout was updated, as it may
     // take some time to load the MSIE control:
-    if ( showRelnotes )
-        ShowReleaseNotes(info);
+    if (showRelnotes)
+    {
+        // ShowReleaseNotes() has been found to generate exceptions 
+        // Uncaught exceptions will cause the CE client to terminate.
+        // Therefore, catch all exceptions, so that the client will remain active!
+        try
+        {
+            ShowReleaseNotes(info);
+        }
+        CATCH_ALL_EXCEPTIONS
+    }
 }
 
 

--- a/src/updatechecker.cpp
+++ b/src/updatechecker.cpp
@@ -325,7 +325,14 @@ void PeriodicUpdateChecker::Run()
             time_t nextCheck = lastCheck + interval;
             if (currentTime >= nextCheck)
             {
-                PerformUpdateCheck(false);
+                try
+                {
+                    // PerformUpdateCheck() will throw on error, for example: appcast file not found 
+                    // Uncaught exceptions will cause this thread (periodic checking) to terminate.
+                    // Therefore, catch all exceptions, so that periodic checking can remain active!
+                    PerformUpdateCheck(false);
+                }
+                CATCH_ALL_EXCEPTIONS
             }
         }
 

--- a/src/updatechecker.h
+++ b/src/updatechecker.h
@@ -67,7 +67,7 @@ protected:
     virtual bool ShouldAutomaticallyInstall() const { return false; }
 
 protected:
-    virtual void PerformUpdateCheck();
+    virtual void PerformUpdateCheck(bool manual);
     virtual bool IsJoinable() const { return false; }
 };
 


### PR DESCRIPTION
We've been getting several BugSplat crash reports related to exceptions  when showing the release notes. This is a pretty simple fix to catch those exceptions so that we don't crash.