### PR TITLE
Fix blank embedded release notes

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -1013,17 +1013,6 @@ void UpdateDialog::ShowReleaseNotes(const Appcast& info)
         auto sizer = new wxBoxSizer(wxVERTICAL);
         sizer->Add(m_webBrowser, wxSizerFlags(1).Expand());
         m_browserParent->SetSizer(sizer);
-
-        // Open all links in the default browser:
-        m_webBrowser->Bind(wxEVT_WEBVIEW_NAVIGATING, [info](wxWebViewEvent& evt)
-        {
-            auto url = evt.GetURL();
-            if (url.starts_with("http") && url != info.ReleaseNotesURL)
-            {
-                wxLaunchDefaultBrowser(url);
-                evt.Veto();
-            }
-        });
     }
 
     if( !info.ReleaseNotesURL.empty() )
@@ -1036,6 +1025,17 @@ void UpdateDialog::ShowReleaseNotes(const Appcast& info)
     }
 
     SetWindowStyleFlag(GetWindowStyleFlag() | wxRESIZE_BORDER);
+
+    // Open all links in the default browser:
+    m_webBrowser->Bind(wxEVT_WEBVIEW_NAVIGATING, [info](wxWebViewEvent& evt)
+    {
+        auto url = evt.GetURL();
+        if (url.starts_with("http") && url != info.ReleaseNotesURL)
+        {
+            wxLaunchDefaultBrowser(url);
+            evt.Veto();
+        }
+    });
 }
 
 

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -1015,15 +1015,15 @@ void UpdateDialog::ShowReleaseNotes(const Appcast& info)
         m_browserParent->SetSizer(sizer);
 
         // Open all links in the default browser:
-		m_webBrowser->Bind(wxEVT_WEBVIEW_NAVIGATING, [info](wxWebViewEvent& evt)
-			{
-				auto url = evt.GetURL();
-                if (url.starts_with("http") && url != info.ReleaseNotesURL)
-                {
-                    wxLaunchDefaultBrowser(url);
-                    evt.Veto();
-                }
-			});
+        m_webBrowser->Bind(wxEVT_WEBVIEW_NAVIGATING, [info](wxWebViewEvent& evt)
+        {
+            auto url = evt.GetURL();
+            if (url.starts_with("http") && url != info.ReleaseNotesURL)
+            {
+                wxLaunchDefaultBrowser(url);
+                evt.Veto();
+            }
+        });
     }
 
     if( !info.ReleaseNotesURL.empty() )


### PR DESCRIPTION
## Description

Fix release notes not rendering in embedded browser by delaying the binding of browser navigation events until after the release notes have been initially loaded.

This way the embedded browser still loads the release notes via URL, but subsequent clicks are routed to the external default browser.

## Motivation & Context

After upgrading from WinSparkle 0.7.0 to WinSparkle 0.8.0, we noticed the release notes were no longer displaying properly in the embedded browser, but instead were loaded externally in the system wide default browser.

The new behavior seems like it was introduced in:
https://github.com/vslavik/winsparkle/commit/ec271892eaefd48edffd9ec2123fd9f9f09f5113

We're guessing the intent was to load the release notes in the embedded browser and only load subsequent links in the external default browser.