### PR TITLE
The update permission request dialog is centered and moved to the top

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ packages
 pascal/lib/
 pascal/backup/
 .vs
+*.aps
+*.bak

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -1343,6 +1343,10 @@ void App::OnUpdateAvailable(wxThreadEvent& event)
 void App::OnAskForPermission(wxThreadEvent& event)
 {
     AskPermissionDialog dlg;
+    // center inside parent window
+    dlg.CentreOnParent();
+    // to the top
+    dlg.Raise();
     bool shouldCheck = (dlg.ShowModal() == wxID_OK);
 
     Settings::WriteConfigValue("CheckForUpdates", shouldCheck);


### PR DESCRIPTION
The **AskPermissionDialog** dialog for requesting permission becomes more visible if it is placed in the center and at the top of the main program window.
Also *.aps and *.bak files added to ignore for git