### PR TITLE
Add update closed event

### DIFF
--- a/include/winsparkle.h
+++ b/include/winsparkle.h
@@ -459,6 +459,23 @@ typedef void (__cdecl *win_sparkle_update_cancelled_callback_t)();
 */
 WIN_SPARKLE_API void __cdecl win_sparkle_set_update_cancelled_callback(win_sparkle_update_cancelled_callback_t callback);
 
+/// Callback type for win_sparkle_update_closed_callback_t()
+typedef void(__cdecl *win_sparkle_update_closed_callback_t)();
+
+/**
+    Set callback to be called when the download dialog is closed
+    even by the user or at the end of the process.
+
+    This is useful in combination with
+    win_sparkle_check_update_with_ui_and_install() as it allows you to perform
+    some action when the update download process end (by user action or installation starts).
+
+    @since 8.2
+
+    @see win_sparkle_check_update_with_ui_and_install()
+*/
+WIN_SPARKLE_API void __cdecl win_sparkle_set_update_closed_callback(win_sparkle_update_closed_callback_t callback);
+
 /// Callback type for win_sparkle_update_skipped_callback()
 typedef void(__cdecl* win_sparkle_update_skipped_callback_t)();
 

--- a/src/appcontroller.cpp
+++ b/src/appcontroller.cpp
@@ -37,6 +37,7 @@ win_sparkle_shutdown_request_callback_t    ApplicationController::ms_cbRequestSh
 win_sparkle_did_find_update_callback_t     ApplicationController::ms_cbDidFindUpdate = NULL;
 win_sparkle_did_not_find_update_callback_t ApplicationController::ms_cbDidNotFindUpdate = NULL;
 win_sparkle_update_cancelled_callback_t    ApplicationController::ms_cbUpdateCancelled = NULL;
+win_sparkle_update_closed_callback_t       ApplicationController::ms_cbUpdateClosed = NULL;
 win_sparkle_update_skipped_callback_t      ApplicationController::ms_cbUpdateSkipped = NULL;
 win_sparkle_update_postponed_callback_t    ApplicationController::ms_cbUpdatePostponed = NULL;
 win_sparkle_update_dismissed_callback_t    ApplicationController::ms_cbUpdateDismissed = NULL;
@@ -114,6 +115,17 @@ void ApplicationController::NotifyUpdateCancelled()
         if ( ms_cbUpdateCancelled )
         {
             (*ms_cbUpdateCancelled)();
+            return;
+        }
+    }
+}
+
+void ApplicationController::NotifyUpdateClosed() {
+    {
+        CriticalSectionLocker lock(ms_csVars);
+        if (ms_cbUpdateClosed)
+        {
+            (*ms_cbUpdateClosed)();
             return;
         }
     }

--- a/src/appcontroller.h
+++ b/src/appcontroller.h
@@ -69,6 +69,9 @@ public:
     /// Notify that an update was cancelled.
     static void NotifyUpdateCancelled();
 
+    /// Notify that an update was close.
+    static void NotifyUpdateClosed();
+
     /// Notify that an update was skipped
     static void NotifyUpdateSkipped();
 
@@ -130,6 +133,13 @@ public:
         ms_cbUpdateCancelled = callback;
     }
 
+    /// Set the win_sparkle_update_closed_callback_t function
+    static void SetUpdateClosedCallback(win_sparkle_update_closed_callback_t callback)
+    {
+        CriticalSectionLocker lock(ms_csVars);
+        ms_cbUpdateClosed = callback;
+    }
+
     /// Set the win_sparkle_update_skipped_callback_t function
     static void SetUpdateSkippedCallback(win_sparkle_update_skipped_callback_t callback)
     {
@@ -171,6 +181,7 @@ private:
     static win_sparkle_did_find_update_callback_t     ms_cbDidFindUpdate;
     static win_sparkle_did_not_find_update_callback_t ms_cbDidNotFindUpdate;
     static win_sparkle_update_cancelled_callback_t    ms_cbUpdateCancelled;
+    static win_sparkle_update_closed_callback_t       ms_cbUpdateClosed;
     static win_sparkle_update_skipped_callback_t      ms_cbUpdateSkipped;
     static win_sparkle_update_postponed_callback_t    ms_cbUpdatePostponed;
     static win_sparkle_update_dismissed_callback_t    ms_cbUpdateDismissed;

--- a/src/dll_api.cpp
+++ b/src/dll_api.cpp
@@ -342,6 +342,15 @@ WIN_SPARKLE_API void __cdecl win_sparkle_set_update_cancelled_callback(win_spark
     CATCH_ALL_EXCEPTIONS
 }
 
+WIN_SPARKLE_API void __cdecl win_sparkle_set_update_closed_callback(win_sparkle_update_closed_callback_t callback)
+{
+    try
+    {
+        ApplicationController::SetUpdateClosedCallback(callback);
+    }
+    CATCH_ALL_EXCEPTIONS
+}
+
 WIN_SPARKLE_API void __cdecl win_sparkle_set_update_skipped_callback(win_sparkle_update_skipped_callback_t callback)
 {
     try

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -618,8 +618,10 @@ void UpdateDialog::OnClose(wxCloseEvent&)
     // If the update was not downloaded and the appcast is empty and we're closing,
     // it means that we're about to restart or there was an error, and that the
     // window-close event wasn't initiated by the user.
-    if ( m_appcast.IsValid() && m_updateFile.IsEmpty() && !m_errorOccurred )
+    if (m_appcast.IsValid() && m_updateFile.IsEmpty() && !m_errorOccurred)
         ApplicationController::NotifyUpdateCancelled();
+
+    ApplicationController::NotifyUpdateClosed();
 }
 
 

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -618,7 +618,7 @@ void UpdateDialog::OnClose(wxCloseEvent&)
     // If the update was not downloaded and the appcast is empty and we're closing,
     // it means that we're about to restart or there was an error, and that the
     // window-close event wasn't initiated by the user.
-    if (m_appcast.IsValid() && m_updateFile.IsEmpty() && !m_errorOccurred)
+    if ( m_appcast.IsValid() && m_updateFile.IsEmpty() && !m_errorOccurred )
         ApplicationController::NotifyUpdateCancelled();
 
     ApplicationController::NotifyUpdateClosed();


### PR DESCRIPTION
This is a solution candidate for #127 issue (duplicated #271) where WinSparkle library user can suscribe to a new event emitted when the updater closes (`win_sparkle_set_update_closed_callback`).