### PR TITLE
Dev/min autoupdate version

### DIFF
--- a/src/appcast.cpp
+++ b/src/appcast.cpp
@@ -25,6 +25,8 @@
 
 #include "appcast.h"
 #include "error.h"
+#include "settings.h"
+#include "updatechecker.h"
 
 #include <expat.h>
 #include <vector>
@@ -226,6 +228,22 @@ bool is_suitable_windows_item(const Appcast &item)
 #else
     return item.Os.compare(OS_MARKER_LEN, std::string::npos, "-x86") == 0;
 #endif // _WIN64
+}
+
+/**
+* Returns true is no minimum update version is set or
+* if the current version is >= MinAutoUpdateVersion
+*/
+bool is_suitable_update_item(const Appcast& item)
+{
+    const std::string currentVersion = WideToAnsi(Settings::GetAppBuildVersion());
+    return item.MinAutoUpdateVersion.empty() || UpdateChecker::CompareVersions(currentVersion, item.MinAutoUpdateVersion) >= 0;
+}
+
+
+bool is_suitable_windows_and_update_item(const Appcast& item)
+{
+    return is_suitable_windows_item(item) && is_suitable_update_item(item);
 }
 
 

--- a/src/appcast.cpp
+++ b/src/appcast.cpp
@@ -300,12 +300,13 @@ void XMLCALL OnEndElement(void *data, const char *name)
         {
             ctxt.in_min_autoupdate_version--;
         }
-    }
-    else if (ctxt.in_channel && strcmp(name, NODE_ITEM) == 0)
-    {
-        ctxt.in_item--;
-        if (is_suitable_windows_item(ctxt.items[ctxt.items.size() - 1]))
-            XML_StopParser(ctxt.parser, XML_TRUE);
+        else if (strcmp(name, NODE_ITEM) == 0)
+        {
+            ctxt.in_item--;
+
+            if (is_suitable_windows_and_update_item(ctxt.items.back()))
+                XML_StopParser(ctxt.parser, XML_TRUE);
+        }
     }
     else if (strcmp(name, NODE_CHANNEL) == 0 )
     {

--- a/src/appcast.cpp
+++ b/src/appcast.cpp
@@ -68,6 +68,7 @@ namespace
 #define NODE_DSASIGNATURE ATTR_DSASIGNATURE
 #define OS_MARKER       "windows"
 #define OS_MARKER_LEN   7
+#define NODE_MIN_AUTOUPDATE_VERSION   NS_SPARKLE_NAME("minimumAutoupdateVersion")
 
 // context data for the parser
 struct ContextData
@@ -85,7 +86,7 @@ struct ContextData
     int in_channel, in_item, in_relnotes, in_title, in_description, in_link;
 
     // is inside <sparkle:version> or <sparkle:shortVersionString> node?
-    int in_version, in_shortversion, in_dsasignature, in_min_os_version;
+    int in_version, in_shortversion, in_dsasignature, in_min_os_version, in_min_autoupdate_version;
 
     // parsed <item>s
     std::vector<Appcast> items;
@@ -189,6 +190,10 @@ void XMLCALL OnStartElement(void *data, const char *name, const char **attrs)
             if (!ctxt.items.empty())
                 ctxt.items.back().CriticalUpdate = true;
         }
+        else if (strcmp(name, NODE_MIN_AUTOUPDATE_VERSION) == 0)
+        {
+            ctxt.in_min_autoupdate_version++;
+        }
     }
 }
 
@@ -273,6 +278,10 @@ void XMLCALL OnEndElement(void *data, const char *name)
         {
             ctxt.in_dsasignature--;
         }
+        else if (strcmp(name, NODE_MIN_AUTOUPDATE_VERSION) == 0)
+        {
+            ctxt.in_min_autoupdate_version--;
+        }
     }
     else if (ctxt.in_channel && strcmp(name, NODE_ITEM) == 0)
     {
@@ -331,6 +340,10 @@ void XMLCALL OnText(void *data, const char *s, int len)
     else if (ctxt.in_min_os_version)
     {
         item.MinOSVersion.append(s, len);
+    }
+    else if (ctxt.in_min_autoupdate_version)
+    {
+        item.MinAutoUpdateVersion.append(s, len);
     }
 }
 

--- a/src/appcast.cpp
+++ b/src/appcast.cpp
@@ -443,4 +443,15 @@ Appcast Appcast::Load(const std::string& xml)
     }
 }
 
+/**
+* Returns true if Version is not empty and
+* Os is empty or starts with OS_MARKER
+*/
+bool Appcast::IsValid() const
+{
+    return !Version.empty() &&
+        (Os.empty() || Os.compare(0, OS_MARKER_LEN, OS_MARKER) == 0);
+}
+
+
 } // namespace winsparkle

--- a/src/appcast.cpp
+++ b/src/appcast.cpp
@@ -430,7 +430,7 @@ Appcast Appcast::Load(const std::string& xml)
      * or "windows-x64"/"windows-arm64"/"windows-x86" based on this modules bitness and meets the minimum
      * os version, if set. If none, use the first item that meets the minimum os version, if set.
      */
-    std::vector<Appcast>::iterator it = std::find_if(ctxt.items.begin(), ctxt.items.end(), is_suitable_windows_item);
+    std::vector<Appcast>::iterator it = std::find_if(ctxt.items.begin(), ctxt.items.end(), is_suitable_windows_and_update_item);
     if (it != ctxt.items.end())
         return *it;
     else

--- a/src/appcast.h
+++ b/src/appcast.h
@@ -87,7 +87,7 @@ struct Appcast
     static Appcast Load(const std::string& xml);
 
     /// Returns true if the struct constains valid data.
-    bool IsValid() const { return !Version.empty(); }
+    bool IsValid() const;
 
     /// If true, then download and install the update ourselves.
     /// If false, launch a web browser to WebBrowserURL.

--- a/src/appcast.h
+++ b/src/appcast.h
@@ -39,6 +39,7 @@ struct Appcast
     /// App version fields
     std::string Version;
     std::string ShortVersionString;
+    std::string MinAutoUpdateVersion;
 
     /// URL of the update
     std::string DownloadURL;

--- a/src/updatechecker.cpp
+++ b/src/updatechecker.cpp
@@ -242,7 +242,7 @@ void UpdateChecker::PerformUpdateCheck()
                 WideToAnsi(Settings::GetAppBuildVersion());
 
         // Check if our version is out of date.
-        if ( !appcast.IsValid() || CompareVersions(currentVersion, appcast.Version) >= 0 )
+        if ( !appcast.IsValid() || CompareVersions(currentVersion, appcast.MinAutoUpdateVersion) < 0 || CompareVersions(currentVersion, appcast.Version) >= 0 )
         {
             // The same or newer version is already installed.
             UI::NotifyNoUpdates(ShouldAutomaticallyInstall());


### PR DESCRIPTION
Hello.

This PR adds the feature to use minimumAutoupdateVersion in appcast.xml.
It also fixes some other issues:
- handles multiple enclosure-tags by only accepting "windows" as operating system. Not specifying the os is still valid.
- IsValid also checks if Os is empty or starts with "windows"
- corrects the closing of item-tag

I tried to keep the original behaviour intact and committed each step for better clarity. Please let me know what you think.