### PR TITLE
Correct closing of NODE_ITEM

### DIFF
--- a/src/appcast.cpp
+++ b/src/appcast.cpp
@@ -273,12 +273,12 @@ void XMLCALL OnEndElement(void *data, const char *name)
         {
             ctxt.in_dsasignature--;
         }
-    }
-    else if (ctxt.in_channel && strcmp(name, NODE_ITEM) == 0)
-    {
-        ctxt.in_item--;
-        if (is_suitable_windows_item(ctxt.items[ctxt.items.size() - 1]))
-            XML_StopParser(ctxt.parser, XML_TRUE);
+        else if (strcmp(name, NODE_ITEM) == 0)
+        {
+            ctxt.in_item--;
+            if (is_suitable_windows_item(ctxt.items[ctxt.items.size() - 1]))
+                XML_StopParser(ctxt.parser, XML_TRUE);
+        }
     }
     else if (strcmp(name, NODE_CHANNEL) == 0 )
     {


### PR DESCRIPTION
When OnEndElement(...) is called ctxt.in_item is still > 0. Therefore checking if the closing node is NODE_ITEM needs to happen inside that conditional block to decrease ctxt.in_item and possibly stop parsing.