### PR TITLE
Check Os in IsValid()

### DIFF
--- a/src/appcast.cpp
+++ b/src/appcast.cpp
@@ -386,4 +386,15 @@ Appcast Appcast::Load(const std::string& xml)
     }
 }
 
+
+/**
+* Returns true if Version is not empty and
+* Os is empty or starts with OS_MARKER
+*/
+bool Appcast::IsValid() const
+{
+    return !Version.empty() &&
+        (Os.empty() || Os.compare(0, OS_MARKER_LEN, OS_MARKER) == 0);
+}
+
 } // namespace winsparkle

--- a/src/appcast.h
+++ b/src/appcast.h
@@ -86,7 +86,7 @@ struct Appcast
     static Appcast Load(const std::string& xml);
 
     /// Returns true if the struct constains valid data.
-    bool IsValid() const { return !Version.empty(); }
+    bool IsValid() const;
 
     /// If true, then download and install the update ourselves.
     /// If false, launch a web browser to WebBrowserURL.


### PR DESCRIPTION
If a non-windows Os is set the update item should not be valid. Consider an update item with an enclosure for a non-windows version.

This change additionally checks if Os is either empty or starts with OS_MARKER. It also moves the implementation into appcast.cpp so it has access to OS_MARKER_LEN and OS_MARKER.