### PR TITLE
Fix base64_encode including '\0' in output.

### DIFF
--- a/tools/winsparkle-tool.cpp
+++ b/tools/winsparkle-tool.cpp
@@ -57,7 +57,10 @@ std::string base64_encode(const uint8_t* data, size_t len)
     {
         throw std::runtime_error("Failed to encode as base64");
     }
-
+    else if (str.size() > base64_len)
+    {
+        str.resize(base64_len);
+    }
     return str;
 }
 


### PR DESCRIPTION
CryptBinaryToStringA([in, out] pcchString) has unusual behavior

> If pszString is NULL, the function calculates the length of the return
> string (including the terminating null character) in TCHARs

> If pszString is not NULL and big enough, the function converts the
> binary data into a specified string format including the terminating null
> character, but pcchString receives the length in TCHARs,
> **not including the terminating null character**

So it requests a buffer size with room for a terminating '\0', and will write that terminator, but won't count it in the final length. And this std::string likewise implies a '\0'-termination, but doesn't consider that part of std::string::size().

The terminator written by CryptBinaryToStringA shouldn't be left as part of the content of str.

---

Currently this is causing winsparkle-tool to print embedded `'\0` characters in the output of `public-key`, `sign`, etc. Which isn't visible in most terminals, but you can see it if you do e.g. `winsparkle-tool ... | xxd`, and it can mess up if scripts capture the output.