### PR TITLE
Send custom HTTP header in download update request

### DIFF
--- a/include/winsparkle.h
+++ b/include/winsparkle.h
@@ -276,7 +276,7 @@ WIN_SPARKLE_API void __cdecl win_sparkle_set_app_details(const wchar_t *company_
 WIN_SPARKLE_API void __cdecl win_sparkle_set_app_build_version(const wchar_t *build);
 
 /**
-    Set custom HTTP header for appcast checks.
+    Set custom HTTP header for appcast checks and update downloads.
 
     @since 0.7
 

--- a/src/updatedownloader.cpp
+++ b/src/updatedownloader.cpp
@@ -177,7 +177,7 @@ void UpdateDownloader::Run()
       Settings::WriteConfigValue("UpdateTempDir", tmpdir);
 
       UpdateDownloadSink sink(*this, tmpdir);
-      DownloadFile(m_appcast.enclosure.DownloadURL, &sink, this);
+      DownloadFile(m_appcast.enclosure.DownloadURL, &sink, this, Settings::GetHttpHeadersString());
       sink.Close();
 
       if (Settings::HasEdDSAPubKey())


### PR DESCRIPTION
I ran into a situation where I need to pass an `Authorization` header in the HTTP request that gets the appcast file. `win_sparkle_set_http_header` works well for this, but I _also_ need to pass this header when downloading the update installer.

I tried to think of a situation when this behaviour would be undesirable. I checked Sparkle, and it appears that setting [`SPUUpdater.httpHeaders`](https://sparkle-project.github.io/documentation/api-reference/Classes/SPUUpdater.html#/c:objc(cs)SPUUpdater(py)httpHeaders) applies the headers to all HTTP requests. 

> The HTTP headers used when checking for updates, downloading release notes, and downloading updates.