### PR TITLE
Fix release notes when URL is redirected

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -482,6 +482,8 @@ private:
     bool m_errorOccurred;
     // whether window closure was updater-initiated (i.e. not caused by user)
     bool m_closeInitiatedByUpdater;
+    // whether the web browser has loaded the release notes
+    bool m_webBrowserLoaded;
 
     static const int RELNOTES_WIDTH = 460;
     static const int RELNOTES_HEIGHT = 200;
@@ -495,6 +497,7 @@ UpdateDialog::UpdateDialog()
     m_installAutomatically = false;
     m_errorOccurred = false;
     m_closeInitiatedByUpdater = false;
+    m_webBrowserLoaded = false;
 
     m_heading = new wxStaticText(this, wxID_ANY, "");
     SetHeadingFont(m_heading);
@@ -1033,17 +1036,23 @@ void UpdateDialog::ShowReleaseNotes(const Appcast& info)
         sizer->Add(m_webBrowser, wxSizerFlags(1).Expand());
         m_browserParent->SetSizer(sizer);
 
-        // Open all links in the default browser:
-		m_webBrowser->Bind(wxEVT_WEBVIEW_NAVIGATING, [info](wxWebViewEvent& evt)
+        // Open all links in the default browser once the documented is loaded.
+        // Multiple navigating events occur if there are HTTP redirects.
+        m_webBrowser->Bind(wxEVT_WEBVIEW_LOADED, [this](wxWebViewEvent& evt)
+            {
+                this->m_webBrowserLoaded = true;
+            });
+		m_webBrowser->Bind(wxEVT_WEBVIEW_NAVIGATING, [this](wxWebViewEvent& evt)
 			{
-				auto url = evt.GetURL();
-                if (url.starts_with("http") && url != info.ReleaseNotesURL)
+				auto& url = evt.GetURL();
+                if (this->m_webBrowserLoaded && url.starts_with("http"))
                 {
                     wxLaunchDefaultBrowser(url);
                     evt.Veto();
                 }
 			});
     }
+    m_webBrowserLoaded = false;
 
     if( !info.ReleaseNotesURL.empty() )
     {


### PR DESCRIPTION
This fixes https://github.com/vslavik/winsparkle/issues/293 where release notes are loaded in an external browser if the HTTP response is a redirect. This became an issue in ec271892eaefd48edffd9ec2123fd9f9f09f5113, when a `wxEVT_WEBVIEW_NAVIGATING` event handler was added to open clicked links in the browser. The problem is that a redirect generates an additional `wxEVT_WEBVIEW_NAVIGATING` event with the new URL, and that event was treated as a click.

`wxEVT_WEBVIEW_NAVIGATING` does not contain information to differentiate between an initial redirect and a clicked link. There is an action field, but it is not set by this event.

Instead, we can wait for the `wxEVT_WEBVIEW_LOADED` event, and treat any `wxEVT_WEBVIEW_NAVIGATING` event that occurs afterwards as a click. All of the initial `wxEVT_WEBVIEW_NAVIGATING` events occur before `wxEVT_WEBVIEW_LOADED`.

Tested:
- A release notes URL that redirects (HTTP 301 and 302)
- A release notes URL that does not redirect
- A HTML description string instead of a release notes URL

I left in the `url.starts_with("http")` check to be safe, but I think that only existed to ignore `wxEVT_WEBVIEW_NAVIGATING` when using an HTML description string instead of a release notes URL. If that's all that check was for, then it can be removed.

I only have access to an older Windows machine currently, so I've only been able to test this with the IE backend.