### PR TITLE
Adds support for silent, in-app installation of MSIX / MSIXBundle updates.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: Build DLL
-    runs-on: windows-latest
+    runs-on: windows-2022
     strategy:
       matrix:
         platform: [Win32, x64, ARM64]

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+Version 0.9.4
+-------------
+
+- Added silent installation of MSIX/MSIXBundle updates. Mark the enclosure with
+  sparkle:installerType="msix" and WinSparkle installs it via the OS deployment
+  API (no App Installer GUI), shows install progress, and relaunches the app.
+
 Version 0.9.3
 -------------
 

--- a/WinSparkle.WinRT.props
+++ b/WinSparkle.WinRT.props
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemDefinitionGroup>
+    <Link>
+      <!--
+        C++/WinRT calls WinRT runtime functions that are not available on
+        pre-Windows 10 systems. Delay-load those WinRT runtime imports so
+        WinSparkle.dll still loads there; the MSIX code checks availability
+        before calling into WinRT code.
+
+        runtimeobject.lib provides the Ro*/Windows*String imports used by the
+        C++/WinRT projection. If a future SDK requires windowsapp.lib instead,
+        adjust these linker inputs accordingly.
+
+        Keep DelayLoadDLLs in sync with the built binary; verify the exact set
+        with:
+
+            dumpbin /imports WinSparkle.dll
+      -->
+      <AdditionalDependencies>runtimeobject.lib;delayimp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DelayLoadDLLs>api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-1.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+    </Link>
+  </ItemDefinitionGroup>
+</Project>

--- a/WinSparkle.vcxproj
+++ b/WinSparkle.vcxproj
@@ -171,7 +171,11 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>comctl32.lib;kernel32.lib;user32.lib;rpcrt4.lib;version.lib;wininet.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;kernel32.lib;user32.lib;rpcrt4.lib;version.lib;wininet.lib;shlwapi.lib;runtimeobject.lib;delayimp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <!-- Delay-load the WinRT runtime so WinSparkle.dll still loads on pre-Win10
+           systems (the MSIX install path is gated at runtime and never touches
+           these there). Verify the exact set with `dumpbin /imports`. -->
+      <DelayLoadDLLs>api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-string-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-1.dll;api-ms-win-core-winrt-roparameterizediid-l1-1-0.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -191,7 +195,11 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>comctl32.lib;kernel32.lib;user32.lib;rpcrt4.lib;version.lib;wininet.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;kernel32.lib;user32.lib;rpcrt4.lib;version.lib;wininet.lib;shlwapi.lib;runtimeobject.lib;delayimp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <!-- Delay-load the WinRT runtime so WinSparkle.dll still loads on pre-Win10
+           systems (the MSIX install path is gated at runtime and never touches
+           these there). Verify the exact set with `dumpbin /imports`. -->
+      <DelayLoadDLLs>api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-string-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-1.dll;api-ms-win-core-winrt-roparameterizediid-l1-1-0.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
@@ -211,7 +219,11 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>comctl32.lib;kernel32.lib;user32.lib;rpcrt4.lib;version.lib;wininet.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;kernel32.lib;user32.lib;rpcrt4.lib;version.lib;wininet.lib;shlwapi.lib;runtimeobject.lib;delayimp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <!-- Delay-load the WinRT runtime so WinSparkle.dll still loads on pre-Win10
+           systems (the MSIX install path is gated at runtime and never touches
+           these there). Verify the exact set with `dumpbin /imports`. -->
+      <DelayLoadDLLs>api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-string-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-1.dll;api-ms-win-core-winrt-roparameterizediid-l1-1-0.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -314,6 +326,10 @@
     <ClCompile Include="src\updatechecker.cpp" />
     <ClCompile Include="src\updatedownloader.cpp" />
     <ClCompile Include="src\signatureverifier.cpp" />
+    <ClCompile Include="src\msix.cpp">
+      <!-- C++/WinRT (Windows.Management.Deployment) requires C++17. -->
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\winsparkle.h" />
@@ -329,6 +345,7 @@
     <ClInclude Include="src\updatedownloader.h" />
     <ClInclude Include="src\utils.h" />
     <ClInclude Include="src\signatureverifier.h" />
+    <ClInclude Include="src\msix.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="src\winsparkle.rc" />

--- a/WinSparkle.vcxproj
+++ b/WinSparkle.vcxproj
@@ -116,21 +116,27 @@
   <ImportGroup Label="ExtensionSettings" />
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
+    <Import Project="WinSparkle.WinRT.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
+    <Import Project="WinSparkle.WinRT.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="WinSparkle.WinRT.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
+    <Import Project="WinSparkle.WinRT.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
+    <Import Project="WinSparkle.WinRT.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="WinSparkle.WinRT.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -171,11 +177,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>comctl32.lib;kernel32.lib;user32.lib;rpcrt4.lib;version.lib;wininet.lib;shlwapi.lib;runtimeobject.lib;delayimp.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <!-- Delay-load the WinRT runtime so WinSparkle.dll still loads on pre-Win10
-           systems (the MSIX install path is gated at runtime and never touches
-           these there). Verify the exact set with `dumpbin /imports`. -->
-      <DelayLoadDLLs>api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-string-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-1.dll;api-ms-win-core-winrt-roparameterizediid-l1-1-0.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <AdditionalDependencies>comctl32.lib;kernel32.lib;user32.lib;rpcrt4.lib;version.lib;wininet.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -195,11 +197,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>comctl32.lib;kernel32.lib;user32.lib;rpcrt4.lib;version.lib;wininet.lib;shlwapi.lib;runtimeobject.lib;delayimp.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <!-- Delay-load the WinRT runtime so WinSparkle.dll still loads on pre-Win10
-           systems (the MSIX install path is gated at runtime and never touches
-           these there). Verify the exact set with `dumpbin /imports`. -->
-      <DelayLoadDLLs>api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-string-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-1.dll;api-ms-win-core-winrt-roparameterizediid-l1-1-0.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <AdditionalDependencies>comctl32.lib;kernel32.lib;user32.lib;rpcrt4.lib;version.lib;wininet.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
@@ -219,11 +217,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>comctl32.lib;kernel32.lib;user32.lib;rpcrt4.lib;version.lib;wininet.lib;shlwapi.lib;runtimeobject.lib;delayimp.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <!-- Delay-load the WinRT runtime so WinSparkle.dll still loads on pre-Win10
-           systems (the MSIX install path is gated at runtime and never touches
-           these there). Verify the exact set with `dumpbin /imports`. -->
-      <DelayLoadDLLs>api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-string-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-1.dll;api-ms-win-core-winrt-roparameterizediid-l1-1-0.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <AdditionalDependencies>comctl32.lib;kernel32.lib;user32.lib;rpcrt4.lib;version.lib;wininet.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -353,6 +347,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="WinSparkle.WinRT.props">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="WinSparkle.Targets">
       <SubType>Designer</SubType>
     </None>

--- a/WinSparkle.vcxproj.filters
+++ b/WinSparkle.vcxproj.filters
@@ -56,6 +56,9 @@
     <ClInclude Include="src\signatureverifier.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\msix.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\appcast.cpp">
@@ -94,6 +97,9 @@
     <ClCompile Include="src\signatureverifier.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\msix.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="src\winsparkle.rc">
@@ -106,5 +112,6 @@
   <ItemGroup>
     <None Include="WinSparkle.Targets" />
     <None Include="packages.config" />
+    <None Include="WinSparkle.WinRT.props" />
   </ItemGroup>
 </Project>

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -80,7 +80,8 @@ set(SOURCES
   ${SOURCE_DIR}/threads.cpp
   ${SOURCE_DIR}/ui.cpp
   ${SOURCE_DIR}/updatechecker.cpp
-  ${SOURCE_DIR}/updatedownloader.cpp)
+  ${SOURCE_DIR}/updatedownloader.cpp
+  ${SOURCE_DIR}/msix.cpp)
 
 set(PUBLIC_HEADERS
   ${ROOT_DIR}/include/winsparkle.h

--- a/src/appcast.cpp
+++ b/src/appcast.cpp
@@ -183,6 +183,7 @@ void trim_whitespace(std::string& s)
 #define ATTR_EDDSASIGNATURE NS_SPARKLE_NAME("edSignature")
 #define ATTR_OS         NS_SPARKLE_NAME("os")
 #define ATTR_ARGUMENTS  NS_SPARKLE_NAME("installerArguments")
+#define ATTR_INSTALLER_TYPE NS_SPARKLE_NAME("installerType")
 #define NODE_VERSION      ATTR_VERSION        // These can be nodes or
 #define NODE_SHORTVERSION ATTR_SHORTVERSION   // attributes.
 #define NODE_DSASIGNATURE ATTR_DSASIGNATURE
@@ -295,6 +296,8 @@ void XMLCALL OnStartElement(void *data, const char *name, const char **attrs)
                     enclosure.OS = value;
                 else if (strcmp(name, ATTR_ARGUMENTS) == 0)
                     enclosure.InstallerArguments = value;
+                else if (strcmp(name, ATTR_INSTALLER_TYPE) == 0)
+                    enclosure.InstallerType = value;
 
                 // legacy syntax where version info was on enclosure, not item:
                 else if (strcmp(name, ATTR_VERSION) == 0)

--- a/src/appcast.h
+++ b/src/appcast.h
@@ -77,6 +77,10 @@ struct Appcast
         // Arguments passed on the the updater executable
         std::string InstallerArguments;
 
+        // Installer type hint (e.g. "msix" to install via the OS deployment API
+        // instead of launching the file with ShellExecuteEx). Empty = default.
+        std::string InstallerType;
+
 		bool IsValid() const { return !DownloadURL.empty(); }
     };
 

--- a/src/msix.cpp
+++ b/src/msix.cpp
@@ -49,6 +49,7 @@
 #include <shlwapi.h>
 
 #include "utils.h"
+#include "threads.h"
 
 #include <winrt/Windows.Foundation.h>
 // Required for the IIterable<Uri> parameter of AddPackageAsync(); without it the
@@ -58,7 +59,6 @@
 
 #include <string>
 #include <stdexcept>
-#include <thread>
 
 // The WinRT runtime imports are delay-loaded (see the /DELAYLOAD entries in the
 // project file) so that WinSparkle.dll still loads on Windows versions that
@@ -166,14 +166,49 @@ void InstallWorker(std::wstring packagePath)
         winrt::uninit_apartment();
 }
 
+
+// This deliberately does not run on the UI thread: that thread is a
+// single-threaded COM apartment (wxWidgets initializes it via OleInitialize), and
+// the blocking DeploymentOperation::get() call in InstallWorker() is illegal there
+// -- C++/WinRT asserts on it in debug builds and it would stall the message pump
+// (deadlock-prone) in release builds. This worker initializes a multi-threaded
+// apartment instead, where the blocking wait is legal and safe.
+//
+// Fire-and-forget: the thread self-destructs once Run() returns
+// (IsJoinable() == false), matching the previous detached-thread behavior.
+class MsixInstallThread : public Thread
+{
+public:
+    explicit MsixInstallThread(const std::wstring& packagePath)
+        : Thread("WinSparkle MSIX installer"), m_packagePath(packagePath)
+    {
+    }
+
+protected:
+    void Run() override
+    {
+        // No initialization that Start() must wait for, so signal readiness
+        // immediately; the deployment below can take a long time and must not
+        // block the (UI) thread that called Start().
+        SignalReady();
+        InstallWorker(m_packagePath);
+    }
+
+    bool IsJoinable() const override { return false; }
+
+private:
+    std::wstring m_packagePath;
+};
+
 } // anonymous namespace
 
 
 void StartMsixInstall(const std::wstring& packagePath)
 {
-    // The deployment runs off the UI thread; progress and completion are reported
-    // back asynchronously via UI::NotifyInstall*().
-    std::thread(InstallWorker, packagePath).detach();
+    // The deployment runs off the UI thread (see MsixInstallThread); progress and
+    // completion are reported back asynchronously via UI::NotifyInstall*(). The
+    // thread is fire-and-forget and deletes itself when finished.
+    (new MsixInstallThread(packagePath))->Start();
 }
 
 } // namespace winsparkle

--- a/src/msix.cpp
+++ b/src/msix.cpp
@@ -60,14 +60,6 @@
 #include <string>
 #include <stdexcept>
 
-// The WinRT runtime imports are delay-loaded (see the /DELAYLOAD entries in the
-// project file) so that WinSparkle.dll still loads on Windows versions that
-// predate MSIX. runtimeobject.lib provides the Ro*/Windows*String imports that
-// the C++/WinRT projection calls into; if a future SDK requires windowsapp.lib
-// instead, adjust the project's linker inputs accordingly.
-#pragma comment(lib, "runtimeobject.lib")
-#pragma comment(lib, "shlwapi.lib")
-
 namespace winsparkle
 {
 

--- a/src/msix.cpp
+++ b/src/msix.cpp
@@ -1,0 +1,190 @@
+/*
+ *  This file is part of WinSparkle (https://winsparkle.org)
+ *
+ *  Copyright (C) 2009-2026 Vaclav Slavik
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#include "msix.h"
+#include "ui.h"
+#include "error.h"
+
+// MSIX silent installation relies on the C++/WinRT projection of
+// Windows.Management.Deployment, which ships with the Windows 10 SDK. When those
+// headers aren't available (e.g. a MinGW build), this file compiles to a stub
+// that simply reports the feature as unsupported.
+#if defined(__has_include)
+    #if __has_include(<winrt/Windows.Management.Deployment.h>)
+        #define WINSPARKLE_HAVE_MSIX 1
+    #endif
+#endif
+
+#ifdef WINSPARKLE_HAVE_MSIX
+
+#ifndef WIN32_LEAN_AND_MEAN
+    #define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+    #define NOMINMAX
+#endif
+#include <windows.h>
+#include <shlwapi.h>
+
+#include "utils.h"
+
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Management.Deployment.h>
+
+#include <string>
+#include <stdexcept>
+#include <thread>
+
+// The WinRT runtime imports are delay-loaded (see the /DELAYLOAD entries in the
+// project file) so that WinSparkle.dll still loads on Windows versions that
+// predate MSIX. runtimeobject.lib provides the Ro*/Windows*String imports that
+// the C++/WinRT projection calls into; if a future SDK requires windowsapp.lib
+// instead, adjust the project's linker inputs accordingly.
+#pragma comment(lib, "runtimeobject.lib")
+#pragma comment(lib, "shlwapi.lib")
+
+namespace winsparkle
+{
+
+namespace
+{
+
+// Probe whether the WinRT deployment API is present before touching any C++/WinRT
+// code. The API set below is absent on pre-Win10 systems; calling into a WinRT
+// function there would trigger a delay-load failure (a structured exception that
+// /EHsc does not catch). Probing first keeps us safe and lets us report cleanly.
+bool IsMsixDeploymentAvailable()
+{
+    HMODULE mod = ::LoadLibraryExW(
+        L"api-ms-win-core-winrt-l1-1-0.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    if (!mod)
+        return false;
+    ::FreeLibrary(mod);
+    return true;
+}
+
+// Turn a local filesystem path into a properly escaped file:// URI, which is what
+// PackageManager.AddPackageAsync() expects.
+std::wstring MakeFileUri(const std::wstring& path)
+{
+    wchar_t url[4096];
+    DWORD len = ARRAYSIZE(url);
+    HRESULT hr = ::UrlCreateFromPathW(path.c_str(), url, &len, 0);
+    if (FAILED(hr))
+        throw std::runtime_error("Cannot build file URI for MSIX package");
+    return std::wstring(url);
+}
+
+void InstallWorker(std::wstring packagePath)
+{
+    if (!IsMsixDeploymentAvailable())
+    {
+        LogError("MSIX deployment API is not available on this version of Windows.");
+        UI::NotifyInstallFinished(false, L"MSIX installation is not supported on this version of Windows.");
+        return;
+    }
+
+    bool apartmentInited = false;
+    try
+    {
+        winrt::init_apartment(winrt::apartment_type::multi_threaded);
+        apartmentInited = true;
+
+        // Register for automatic restart *before* applying the update, so that
+        // Windows relaunches the app after ForceApplicationShutdown swaps files.
+        ::RegisterApplicationRestart(nullptr, 0);
+
+        namespace deploy = winrt::Windows::Management::Deployment;
+
+        deploy::PackageManager manager;
+        auto op = manager.AddPackageAsync(
+            winrt::Windows::Foundation::Uri(MakeFileUri(packagePath)),
+            nullptr,
+            deploy::DeploymentOptions::ForceApplicationShutdown);
+
+        op.Progress([](auto const&, deploy::DeploymentProgress const& progress)
+        {
+            UI::NotifyInstallProgress(static_cast<int>(progress.percentage));
+        });
+
+        deploy::DeploymentResult result = op.get();
+
+        if (result.ExtendedErrorCode() < 0)
+        {
+            std::wstring err(result.ErrorText().c_str());
+            LogError("MSIX deployment failed: " + WideToAnsi(err));
+            UI::NotifyInstallFinished(false, err);
+        }
+        else
+        {
+            UI::NotifyInstallFinished(true, std::wstring());
+        }
+    }
+    catch (const winrt::hresult_error& ex)
+    {
+        std::wstring err(ex.message().c_str());
+        LogError("MSIX deployment error: " + WideToAnsi(err));
+        UI::NotifyInstallFinished(false, err);
+    }
+    catch (const std::exception& ex)
+    {
+        LogError(std::string("MSIX deployment error: ") + ex.what());
+        UI::NotifyInstallFinished(false, L"MSIX installation failed.");
+    }
+    catch (...)
+    {
+        LogError("MSIX deployment failed with an unknown error.");
+        UI::NotifyInstallFinished(false, L"MSIX installation failed.");
+    }
+
+    if (apartmentInited)
+        winrt::uninit_apartment();
+}
+
+} // anonymous namespace
+
+
+void StartMsixInstall(const std::wstring& packagePath)
+{
+    // The deployment runs off the UI thread; progress and completion are reported
+    // back asynchronously via UI::NotifyInstall*().
+    std::thread(InstallWorker, packagePath).detach();
+}
+
+} // namespace winsparkle
+
+#else // !WINSPARKLE_HAVE_MSIX
+
+namespace winsparkle
+{
+
+void StartMsixInstall(const std::wstring& /*packagePath*/)
+{
+    UI::NotifyInstallFinished(false, L"MSIX installation is not supported in this build.");
+}
+
+} // namespace winsparkle
+
+#endif // WINSPARKLE_HAVE_MSIX

--- a/src/msix.cpp
+++ b/src/msix.cpp
@@ -51,6 +51,9 @@
 #include "utils.h"
 
 #include <winrt/Windows.Foundation.h>
+// Required for the IIterable<Uri> parameter of AddPackageAsync(); without it the
+// parameter type is incomplete and the overload won't resolve.
+#include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Management.Deployment.h>
 
 #include <string>

--- a/src/msix.cpp
+++ b/src/msix.cpp
@@ -117,7 +117,7 @@ void InstallWorker(std::wstring packagePath)
 
         // Register for automatic restart *before* applying the update, so that
         // Windows relaunches the app after ForceApplicationShutdown swaps files.
-        ::RegisterApplicationRestart(nullptr, 0);
+        ::RegisterApplicationRestart(L"", RESTART_NO_CRASH | RESTART_NO_HANG | RESTART_NO_REBOOT);
 
         namespace deploy = winrt::Windows::Management::Deployment;
 

--- a/src/msix.h
+++ b/src/msix.h
@@ -1,0 +1,60 @@
+/*
+ *  This file is part of WinSparkle (https://winsparkle.org)
+ *
+ *  Copyright (C) 2009-2026 Vaclav Slavik
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#ifndef _msix_h_
+#define _msix_h_
+
+#include <string>
+
+namespace winsparkle
+{
+
+/**
+    Silently installs (or upgrades) an MSIX/MSIXBundle package.
+
+    This is used for enclosures marked with sparkle:installerType="msix" in the
+    appcast. Unlike .exe/.msi installers (which are launched with ShellExecuteEx),
+    .msix packages cannot be installed silently that way: the shell association
+    for .msix is the App Installer GUI. Instead, this uses the OS deployment API
+    Windows.Management.Deployment.PackageManager.AddPackageAsync() to install the
+    package without any UI of its own.
+
+    The install runs on a background thread and returns immediately. Progress and
+    the final result are reported asynchronously through the UI notification
+    mechanism:
+      - UI::NotifyInstallProgress(percent)         while staging (0..100)
+      - UI::NotifyInstallFinished(success, error)  when finished
+
+    Before applying the update, the running application is registered for
+    automatic restart (RegisterApplicationRestart), so that Windows relaunches it
+    after the package files have been swapped during shutdown.
+
+    @param packagePath  Full local path to the downloaded .msix/.msixbundle file.
+ */
+void StartMsixInstall(const std::wstring& packagePath);
+
+} // namespace winsparkle
+
+#endif // _msix_h_

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -699,7 +699,7 @@ void UpdateDialog::OnRunInstaller(wxCommandEvent&)
     // (the shell would launch the App Installer GUI). Install them through the OS
     // deployment API instead, showing progress in this dialog. Completion is
     // handled asynchronously in StateInstallFinished().
-    if ( wxString(m_installerType.c_str()).IsSameAs("msix", false) )
+    if ( m_installerType == "msix" )
     {
         StateInstalling();
         StartMsixInstall(m_updateFile.ToStdWstring());

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -1019,13 +1019,11 @@ void UpdateDialog::StateInstalling()
 
     SetMessage(_("Installing update..."));
 
-    EnableAutoPulsing(false);
-    m_progress->SetRange(100);
-    m_progress->SetValue(0);
+    EnableAutoPulsing(true);
 
     HIDE(m_heading);
     SHOW(m_progress);
-    SHOW(m_progressLabel);
+    HIDE(m_progressLabel);
     HIDE(m_closeButtonSizer);
     HIDE(m_runInstallerButtonSizer);
     HIDE(m_releaseNotesSizer);
@@ -1041,8 +1039,8 @@ void UpdateDialog::InstallProgress(int percent)
     else if ( percent > 100 )
         percent = 100;
 
-    if ( m_progress->GetRange() != 100 )
-        m_progress->SetRange(100);
+    EnableAutoPulsing(false);
+    m_progress->SetRange(100);
     m_progress->SetValue(percent);
 
     wxString label = wxString::Format("%d%%", percent);

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -29,6 +29,7 @@
 #include "updatechecker.h"
 #include "updatedownloader.h"
 #include "appcontroller.h"
+#include "msix.h"
 
 #define wxNO_NET_LIB
 #define wxNO_XML_LIB
@@ -156,6 +157,9 @@ struct EventPayload
     std::wstring updateFile;
     bool         installAutomatically;
     ErrorCode    error;
+    int          installPercent;
+    bool         installSuccess;
+    std::wstring installError;
 };
 
 
@@ -430,7 +434,13 @@ public:
     // update download progress
     void DownloadProgress(size_t downloaded, size_t total);
     // change state into "update downloaded"
-    void StateUpdateDownloaded(const std::wstring& updateFile, const std::string &installerArguments);
+    void StateUpdateDownloaded(const std::wstring& updateFile, const std::string &installerArguments, const std::string &installerType);
+    // change state into "installing update" (silent MSIX install)
+    void StateInstalling();
+    // update silent MSIX install progress (0..100)
+    void InstallProgress(int percent);
+    // silent MSIX install finished (success -> shut down & relaunch; failure -> show error)
+    void StateInstallFinished(bool success, const std::wstring& errorText);
 
 private:
     void EnablePulsing(bool enable);
@@ -474,6 +484,8 @@ private:
     wxString m_updateFile;
     // space separated arguments to update file (only valid after StateUpdateDownloaded)
     std::string m_installerArguments;
+    // installer type hint, e.g. "msix" (only valid after StateUpdateDownloaded)
+    std::string m_installerType;
     // downloader (only valid between OnInstall and OnUpdateDownloaded)
     UpdateDownloader* m_downloader;
     // whether the update should be installed without prompting the user
@@ -680,6 +692,17 @@ void UpdateDialog::OnRunInstaller(wxCommandEvent&)
                             wxOK | wxOK_DEFAULT | wxICON_EXCLAMATION);
         dlg.SetExtendedMessage(_("Make sure that you don't have any unsaved documents and try again."));
         dlg.ShowModal();
+        return;
+    }
+
+    // MSIX/MSIXBundle packages cannot be installed silently via ShellExecuteEx
+    // (the shell would launch the App Installer GUI). Install them through the OS
+    // deployment API instead, showing progress in this dialog. Completion is
+    // handled asynchronously in StateInstallFinished().
+    if ( wxString(m_installerType.c_str()).IsSameAs("msix", false) )
+    {
+        StateInstalling();
+        StartMsixInstall(m_updateFile.ToStdWstring());
         return;
     }
 
@@ -983,7 +1006,92 @@ void UpdateDialog::DownloadProgress(size_t downloaded, size_t total)
 }
 
 
-void UpdateDialog::StateUpdateDownloaded(const std::wstring& updateFile, const std::string& installerArguments)
+void UpdateDialog::StateInstalling()
+{
+    LayoutChangesGuard guard(this);
+
+    SetMessage(_("Installing update..."));
+
+    EnablePulsing(false);
+    m_progress->SetRange(100);
+    m_progress->SetValue(0);
+
+    HIDE(m_heading);
+    SHOW(m_progress);
+    SHOW(m_progressLabel);
+    HIDE(m_closeButtonSizer);
+    HIDE(m_runInstallerButtonSizer);
+    HIDE(m_releaseNotesSizer);
+    HIDE(m_updateButtonsSizer);
+    MakeResizable(false);
+}
+
+
+void UpdateDialog::InstallProgress(int percent)
+{
+    if ( percent < 0 )
+        percent = 0;
+    else if ( percent > 100 )
+        percent = 100;
+
+    if ( m_progress->GetRange() != 100 )
+        m_progress->SetRange(100);
+    m_progress->SetValue(percent);
+
+    wxString label = wxString::Format("%d%%", percent);
+    if ( label != m_progressLabel->GetLabel() )
+        m_progressLabel->SetLabel(label);
+
+    Refresh();
+    Update();
+}
+
+
+void UpdateDialog::StateInstallFinished(bool success, const std::wstring& errorText)
+{
+    if ( success )
+    {
+        // The package is staged; shutting down lets Windows swap the files and
+        // (thanks to RegisterApplicationRestart) relaunch the app afterwards.
+        m_closeInitiatedByUpdater = true;
+        Close();
+        ApplicationController::RequestShutdown();
+        return;
+    }
+
+    // Installation failed: inform the user and return to the "ready to install"
+    // state so they can retry or close the dialog.
+    {
+        wxMessageDialog dlg(this,
+            _("Failed to install the update."),
+            _("Software Update"),
+            wxOK | wxOK_DEFAULT | wxICON_EXCLAMATION);
+        if ( !errorText.empty() )
+            dlg.SetExtendedMessage(wxString(errorText.c_str()));
+        dlg.ShowModal();
+    }
+
+    LayoutChangesGuard guard(this);
+
+    SetMessage(_("Ready to install."));
+
+    m_progress->SetRange(1);
+    m_progress->SetValue(1);
+
+    m_runInstallerButton->SetDefault();
+
+    HIDE(m_heading);
+    SHOW(m_progress);
+    HIDE(m_progressLabel);
+    HIDE(m_closeButtonSizer);
+    SHOW(m_runInstallerButtonSizer);
+    HIDE(m_releaseNotesSizer);
+    HIDE(m_updateButtonsSizer);
+    MakeResizable(false);
+}
+
+
+void UpdateDialog::StateUpdateDownloaded(const std::wstring& updateFile, const std::string& installerArguments, const std::string& installerType)
 {
     m_downloader->Join();
     delete m_downloader;
@@ -991,6 +1099,7 @@ void UpdateDialog::StateUpdateDownloaded(const std::wstring& updateFile, const s
 
     m_updateFile = updateFile;
     m_installerArguments = installerArguments;
+    m_installerType = installerType;
 
     if ( m_installAutomatically )
     {
@@ -1152,6 +1261,12 @@ const int MSG_DOWNLOAD_PROGRESS = wxNewId();
 // Inform the UI that update download finished
 const int MSG_UPDATE_DOWNLOADED = wxNewId();
 
+// Inform the UI about silent MSIX install progress
+const int MSG_INSTALL_PROGRESS = wxNewId();
+
+// Inform the UI that a silent MSIX install finished
+const int MSG_INSTALL_FINISHED = wxNewId();
+
 // Tell the UI to ask for permission to check updates
 const int MSG_ASK_FOR_PERMISSION = wxNewId();
 
@@ -1183,6 +1298,8 @@ private:
     void OnUpdateError(wxThreadEvent& event);
     void OnDownloadProgress(wxThreadEvent& event);
     void OnUpdateDownloaded(wxThreadEvent& event);
+    void OnInstallProgress(wxThreadEvent& event);
+    void OnInstallFinished(wxThreadEvent& event);
     void OnAskForPermission(wxThreadEvent& event);
 
 private:
@@ -1218,6 +1335,8 @@ App::App()
     Bind(wxEVT_COMMAND_THREAD, &App::OnUpdateError, this, MSG_UPDATE_ERROR);
     Bind(wxEVT_COMMAND_THREAD, &App::OnDownloadProgress, this, MSG_DOWNLOAD_PROGRESS);
     Bind(wxEVT_COMMAND_THREAD, &App::OnUpdateDownloaded, this, MSG_UPDATE_DOWNLOADED);
+    Bind(wxEVT_COMMAND_THREAD, &App::OnInstallProgress, this, MSG_INSTALL_PROGRESS);
+    Bind(wxEVT_COMMAND_THREAD, &App::OnInstallFinished, this, MSG_INSTALL_FINISHED);
     Bind(wxEVT_COMMAND_THREAD, &App::OnAskForPermission, this, MSG_ASK_FOR_PERMISSION);
 }
 
@@ -1355,7 +1474,25 @@ void App::OnUpdateDownloaded(wxThreadEvent& event)
     if ( m_win )
     {
         EventPayload payload(event.GetPayload<EventPayload>());
-        m_win->StateUpdateDownloaded(payload.updateFile, payload.appcast.enclosure.InstallerArguments);
+        m_win->StateUpdateDownloaded(payload.updateFile, payload.appcast.enclosure.InstallerArguments, payload.appcast.enclosure.InstallerType);
+    }
+}
+
+void App::OnInstallProgress(wxThreadEvent& event)
+{
+    if ( m_win )
+    {
+        EventPayload payload(event.GetPayload<EventPayload>());
+        m_win->InstallProgress(payload.installPercent);
+    }
+}
+
+void App::OnInstallFinished(wxThreadEvent& event)
+{
+    if ( m_win )
+    {
+        EventPayload payload(event.GetPayload<EventPayload>());
+        m_win->StateInstallFinished(payload.installSuccess, payload.installError);
     }
 }
 
@@ -1546,6 +1683,27 @@ void UI::NotifyUpdateDownloaded(const std::wstring& updateFile, const Appcast &a
     payload.updateFile = updateFile;
     payload.appcast = appcast;
     uit.App().SendMsg(MSG_UPDATE_DOWNLOADED, &payload);
+}
+
+
+/*static*/
+void UI::NotifyInstallProgress(int percent)
+{
+    UIThreadAccess uit;
+    EventPayload payload;
+    payload.installPercent = percent;
+    uit.App().SendMsg(MSG_INSTALL_PROGRESS, &payload);
+}
+
+
+/*static*/
+void UI::NotifyInstallFinished(bool success, const std::wstring& errorText)
+{
+    UIThreadAccess uit;
+    EventPayload payload;
+    payload.installSuccess = success;
+    payload.installError = errorText;
+    uit.App().SendMsg(MSG_INSTALL_FINISHED, &payload);
 }
 
 

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -1043,10 +1043,6 @@ void UpdateDialog::InstallProgress(int percent)
     m_progress->SetRange(100);
     m_progress->SetValue(percent);
 
-    wxString label = wxString::Format("%d%%", percent);
-    if ( label != m_progressLabel->GetLabel() )
-        m_progressLabel->SetLabel(label);
-
     Refresh();
     Update();
 }

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -443,7 +443,7 @@ public:
     void StateInstallFinished(bool success, const std::wstring& errorText);
 
 private:
-    void EnablePulsing(bool enable);
+    void EnableAutoPulsing(bool enable);
     void OnTimer(wxTimerEvent& event);
     void OnCloseButton(wxCommandEvent& event);
     void OnClose(wxCloseEvent& event);
@@ -496,6 +496,8 @@ private:
     bool m_closeInitiatedByUpdater;
     // whether the web browser has loaded the release notes
     bool m_webBrowserPageLoaded;
+    // whether the progress bar shows animated indeterminate state
+    bool m_progressAutoPulsing = false;
 
     static const int RELNOTES_WIDTH = 460;
     static const int RELNOTES_HEIGHT = 200;
@@ -595,8 +597,13 @@ UpdateDialog::UpdateDialog()
 }
 
 
-void UpdateDialog::EnablePulsing(bool enable)
+void UpdateDialog::EnableAutoPulsing(bool enable)
 {
+    if (enable == m_progressAutoPulsing)
+        return;
+
+    m_progressAutoPulsing = enable;
+
     if ( enable && !m_timer.IsRunning() )
         m_timer.Start(100);
     else if ( !enable && m_timer.IsRunning() )
@@ -782,7 +789,7 @@ void UpdateDialog::StateCheckingUpdates()
     SetMessage(_("Checking for updates..."));
 
     m_closeButton->SetLabel(_("Cancel"));
-    EnablePulsing(true);
+    EnableAutoPulsing(true);
 
     HIDE(m_heading);
     SHOW(m_progress);
@@ -830,7 +837,7 @@ void UpdateDialog::StateNoUpdateFound(bool installAutomatically)
 
     m_closeButton->SetLabel(_("Close"));
     m_closeButton->SetDefault();
-    EnablePulsing(false);
+    EnableAutoPulsing(false);
 
     SHOW(m_heading);
     HIDE(m_progress);
@@ -865,7 +872,7 @@ void UpdateDialog::StateUpdateError(ErrorCode err)
 
     m_closeButton->SetLabel(_("Cancel"));
     m_closeButton->SetDefault();
-    EnablePulsing(false);
+    EnableAutoPulsing(false);
 
     SHOW(m_heading);
     HIDE(m_progress);
@@ -924,7 +931,7 @@ void UpdateDialog::StateUpdateAvailable(const Appcast& info, bool installAutomat
             showRelnotes ? RELNOTES_WIDTH : MESSAGE_AREA_WIDTH
         );
 
-        EnablePulsing(false);
+        EnableAutoPulsing(false);
 
         m_installButton->SetDefault();
 
@@ -962,7 +969,7 @@ void UpdateDialog::StateDownloading()
     SetMessage(_("Downloading update..."));
 
     m_closeButton->SetLabel(_("Cancel"));
-    EnablePulsing(false);
+    EnableAutoPulsing(false);
 
     HIDE(m_heading);
     SHOW(m_progress);
@@ -1012,7 +1019,7 @@ void UpdateDialog::StateInstalling()
 
     SetMessage(_("Installing update..."));
 
-    EnablePulsing(false);
+    EnableAutoPulsing(false);
     m_progress->SetRange(100);
     m_progress->SetValue(0);
 

--- a/src/ui.h
+++ b/src/ui.h
@@ -95,6 +95,19 @@ public:
     static void NotifyUpdateDownloaded(const std::wstring& updateFile, const Appcast &appcast);
 
     /**
+        Notifies the UI about progress of a silent MSIX installation (0..100).
+     */
+    static void NotifyInstallProgress(int percent);
+
+    /**
+        Notifies the UI that a silent MSIX installation finished.
+
+        On success, the application is shut down (and relaunched by Windows). On
+        failure, @a errorText describes what went wrong.
+     */
+    static void NotifyInstallFinished(bool success, const std::wstring& errorText);
+
+    /**
         Shows the WinSparkle window in "checking for updates..." state.
      */
     static void ShowCheckingUpdates();


### PR DESCRIPTION
Adds support for silent, in-app installation of MSIX / MSIXBundle updates*

Today WinSparkle launches downloaded installers with `ShellExecuteEx`. That doesn't work for `.msix`/`.msixbundle` packages: the shell association for those is the **App Installer GUI**, so the user is bounced out into a separate Microsoft window and has to click through it manually.

This PR lets an app opt into a fully silent flow by marking the appcast enclosure with `sparkle:installerType="msix"`. WinSparkle then installs the package through the OS deployment API (`Windows.Management.Deployment.PackageManager.AddPackageAsync`), shows staging progress in its own dialog, and relaunches the app once the update is applied.

[MSIX](https://learn.microsoft.com/windows/msix/overview) is Microsoft's modern app packaging format for Windows — it gives any app a reliable clean install/uninstall, differential (block-level) updates, and a package identity that unlocks many Windows platform features. It's also the format the **Microsoft Store requires for published apps**, and it's increasingly used for direct, outside-the-Store distribution.

## Demo

**1. Silent MSIX update — happy path (download → progress → relaunch):**

https://github.com/user-attachments/assets/44fc73f6-2eef-47bf-9afe-157574302e14

**2. How it looks before the changes**

https://github.com/user-attachments/assets/205d4b18-54a6-4889-9fcf-e84a11c626ca

## How to use it

Mark the enclosure in your appcast with the new `sparkle:installerType` attribute:

```xml
<enclosure
    url="https://example.com/MyApp_1.2.3.0_x64.msixbundle"
    sparkle:version="1.2.3.0"
    sparkle:installerType="msix"
    length="12345678"
    type="application/octet-stream" />
```

Anything other than `msix` (including an absent attribute) keeps the existing `ShellExecuteEx` behavior, so this is fully backward compatible.

## How it works

- **Appcast** — parses the new `sparkle:installerType` enclosure attribute (`Appcast::Enclosure::InstallerType`).
- **Install path** — when the type is `msix`, `OnRunInstaller` calls `StartMsixInstall()` instead of launching the file. The install runs on a background thread; progress and completion are marshaled back to the UI thread via `UI::NotifyInstallProgress` / `UI::NotifyInstallFinished`.
- **UI** — new dialog states: `StateInstalling` (determinate progress bar), `InstallProgress` (0–100%), and `StateInstallFinished`. On success the app shuts down so Windows can swap the package files; on failure it shows the error and returns to the "ready to install" state so the user can retry.
- **Relaunch** — `RegisterApplicationRestart` is called before `AddPackageAsync(..., ForceApplicationShutdown)`, so Windows relaunches the app after the files are swapped during shutdown.

## Compatibility & fallback

The MSIX path must not break existing consumers on older Windows or non-MSVC builds:

- **Pre-Windows 10** — the WinRT runtime DLLs are **delay-loaded** (see `DelayLoadDLLs` in the vcxproj), and the code probes `api-ms-win-core-winrt-l1-1-0.dll` at runtime (`IsMsixDeploymentAvailable`) before touching any C++/WinRT code. So `WinSparkle.dll` still loads and runs normally on systems that predate MSIX; the feature simply reports as unsupported.
- **Non-MSVC / MinGW builds** — `msix.cpp` guards on `__has_include(<winrt/...>)` and compiles to a stub that reports "not supported in this build" when the Windows 10 SDK headers aren't present.
- `msix.cpp` is built with **C++17** (required by the C++/WinRT projection); the rest of the project is unaffected.

## Changes

| File | Change |
|------|--------|
| `src/msix.cpp`, `src/msix.h` | **New** — silent MSIX install via `PackageManager`, runtime availability probe, background worker, MinGW stub |
| `src/appcast.cpp`, `src/appcast.h` | Parse `sparkle:installerType` attribute |
| `src/ui.cpp`, `src/ui.h` | Installing/progress/finished states + thread-safe notifications |
| `WinSparkle.vcxproj` | Link `runtimeobject.lib`/`delayimp.lib`, delay-load WinRT DLLs, build `msix.cpp` as C++17 |
| `cmake/CMakeLists.txt` | Add `msix.cpp` to sources |
| `NEWS` | 0.9.4 changelog entry |

